### PR TITLE
add a parameter (long int) to the transport and device API

### DIFF
--- a/lib/v1.0/C/ivy_transport.c
+++ b/lib/v1.0/C/ivy_transport.c
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include <Ivy/ivy.h>
 
-static void put_bytes(struct ivy_transport *trans, struct link_device *dev __attribute__((unused)),
+static void put_bytes(struct ivy_transport *trans, struct link_device *dev __attribute__((unused)), long fd __attribute__((unused)),
                       enum TransportDataType type __attribute__((unused)), enum TransportDataFormat format __attribute__((unused)),
                       uint8_t len, const void *bytes)
 {
@@ -126,7 +126,7 @@ static void put_bytes(struct ivy_transport *trans, struct link_device *dev __att
   }
 }
 
-static void put_named_byte(struct ivy_transport *trans, struct link_device *dev __attribute__((unused)),
+static void put_named_byte(struct ivy_transport *trans, struct link_device *dev __attribute__((unused)), long fd __attribute__((unused)),
                            enum TransportDataType type __attribute__((unused)), enum TransportDataFormat format __attribute__((unused)),
                            uint8_t byte __attribute__((unused)), const char *name __attribute__((unused)))
 {
@@ -138,13 +138,13 @@ static uint8_t size_of(struct ivy_transport *trans __attribute__((unused)), uint
   return len;
 }
 
-static void start_message(struct ivy_transport *trans, struct link_device *dev __attribute__((unused)),
+static void start_message(struct ivy_transport *trans, struct link_device *dev __attribute__((unused)), long fd __attribute__((unused)),
                           uint8_t payload_len __attribute__((unused)))
 {
   trans->ivy_p = trans->ivy_buf;
 }
 
-static void end_message(struct ivy_transport *trans, struct link_device *dev)
+static void end_message(struct ivy_transport *trans, struct link_device *dev, long fd __attribute__((unused)))
 {
   *(--trans->ivy_p) = '\0';
   if (trans->ivy_dl_enabled) {
@@ -164,14 +164,14 @@ static void count_bytes(struct ivy_transport *trans __attribute__((unused)), str
 }
 
 static int check_available_space(struct ivy_transport *trans __attribute__((unused)),
-                                 struct link_device *dev __attribute__((unused)), uint8_t bytes __attribute__((unused)))
+                                 struct link_device *dev __attribute__((unused)), long *fd __attribute__((unused)), uint8_t bytes __attribute__((unused)))
 {
   return 1;
 }
 
-static int check_free_space(struct ivy_transport *t __attribute__((unused)), uint8_t len __attribute__((unused))) { return true; }
-static void transmit(struct ivy_transport *t __attribute__((unused)), uint8_t byte __attribute__((unused))) {}
-static void send_message(struct ivy_transport *t __attribute__((unused))) {}
+static int check_free_space(struct ivy_transport *t __attribute__((unused)), long *fd __attribute__((unused)), uint8_t len __attribute__((unused))) { return 1; }
+static void transmit(struct ivy_transport *t __attribute__((unused)), long fd __attribute__((unused)), uint8_t byte __attribute__((unused))) {}
+static void send_message(struct ivy_transport *t __attribute__((unused)), long fd __attribute__((unused))) {}
 static int null_function(struct ivy_transport *t __attribute__((unused))) { return 0; }
 
 void ivy_transport_init(struct ivy_transport *t)

--- a/lib/v1.0/C/ivy_transport.c
+++ b/lib/v1.0/C/ivy_transport.c
@@ -164,7 +164,7 @@ static void count_bytes(struct ivy_transport *trans __attribute__((unused)), str
 }
 
 static int check_available_space(struct ivy_transport *trans __attribute__((unused)),
-                                 struct link_device *dev __attribute__((unused)), long *fd __attribute__((unused)), uint8_t bytes __attribute__((unused)))
+                                 struct link_device *dev __attribute__((unused)), long *fd __attribute__((unused)), uint16_t bytes __attribute__((unused)))
 {
   return 1;
 }

--- a/lib/v1.0/C/pprz_transport.c
+++ b/lib/v1.0/C/pprz_transport.c
@@ -108,7 +108,7 @@ static void count_bytes(struct pprz_transport *trans __attribute__((unused)), st
 }
 
 static int check_available_space(struct pprz_transport *trans __attribute__((unused)), struct link_device *dev,
-                                 long *fd, uint8_t bytes)
+                                 long *fd, uint16_t bytes)
 {
   return dev->check_free_space(dev->periph, fd, bytes);
 }

--- a/lib/v1.0/C/pprzlog_transport.c
+++ b/lib/v1.0/C/pprzlog_transport.c
@@ -104,7 +104,7 @@ static void count_bytes(struct pprzlog_transport *trans __attribute__((unused)),
 }
 
 static int check_available_space(struct pprzlog_transport *trans __attribute__((unused)), struct link_device *dev, long *fd,
-                                 uint8_t bytes)
+                                 uint16_t bytes)
 {
   return dev->check_free_space(dev->periph, fd, bytes);
 }

--- a/lib/v1.0/C/print_utils.h
+++ b/lib/v1.0/C/print_utils.h
@@ -30,40 +30,40 @@
 
 #include "pprzlink/pprzlink_device.h"
 
-static inline void print_string(struct link_device *dev, char *s)
+static inline void print_string(struct link_device *dev, long fd, char *s)
 {
   uint8_t i = 0;
   while (s[i]) {
-    dev->put_byte(dev->periph, s[i]);
+    dev->put_byte(dev->periph, fd, s[i]);
     i++;
   }
 }
 
-static inline void print_hex(struct link_device *dev, uint8_t c)
+static inline void print_hex(struct link_device *dev, long fd, uint8_t c)
 {
   const uint8_t hex[16] =
   { '0', '1', '2', '3', '4', '5', '6', '7',
     '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
   uint8_t high = (c & 0xF0)>>4;
   uint8_t low  = c & 0x0F;
-  dev->put_byte(dev->periph, hex[high]);
-  dev->put_byte(dev->periph, hex[low]);
+  dev->put_byte(dev->periph, fd, hex[high]);
+  dev->put_byte(dev->periph, fd, hex[low]);
 }
 
-static inline void print_hex16(struct link_device *dev, uint16_t c)
+static inline void print_hex16(struct link_device *dev, long fd, uint16_t c)
 {
   uint8_t high16 = (uint8_t)(c>>8);
   uint8_t low16  = (uint8_t)(c);
-  print_hex(dev, high16);
-  print_hex(dev, low16);
+  print_hex(dev, fd, high16);
+  print_hex(dev, fd, low16);
 }
 
-static inline void print_hex32(struct link_device *dev, uint32_t c)
+static inline void print_hex32(struct link_device *dev, long fd, uint32_t c)
 {
   uint16_t high32 = (uint16_t)(c>>16);
   uint16_t low32  = (uint16_t)(c);
-  print_hex16(dev, high32);
-  print_hex16(dev, low32);
+  print_hex16(dev, fd, high32);
+  print_hex16(dev, fd, low32);
 }
 
 #endif /* PRINT_UTILS_H */

--- a/lib/v1.0/C/xbee_transport.c
+++ b/lib/v1.0/C/xbee_transport.c
@@ -162,7 +162,7 @@ static void count_bytes(struct xbee_transport *trans __attribute__((unused)),
 }
 
 static int check_available_space(struct xbee_transport *trans __attribute__((unused)), struct link_device *dev, long *fd,
-                                 uint8_t bytes)
+                                 uint16_t bytes)
 {
   return dev->check_free_space(dev->periph, fd, bytes);
 }

--- a/tools/generator/C/include_v1.0/pprzlink_device.h
+++ b/tools/generator/C/include_v1.0/pprzlink_device.h
@@ -36,9 +36,10 @@
  * they are used to cast the real functions with the correct type
  * to store in the device structure
  */
-typedef int (*check_free_space_t)(void *, uint8_t);
-typedef void (*put_byte_t)(void *, uint8_t);
-typedef void (*send_message_t)(void *);
+typedef int (*check_free_space_t)(void *, long *, uint8_t);
+typedef void (*put_byte_t)(void *, long, uint8_t);
+typedef void (*put_buffer_t)(void *, long, const uint8_t *, uint16_t);
+typedef void (*send_message_t)(void *, long);
 typedef int (*char_available_t)(void *);
 typedef uint8_t (*get_byte_t)(void *);
 typedef void (*set_baudrate_t)(void *, uint32_t baudrate);
@@ -48,6 +49,7 @@ typedef void (*set_baudrate_t)(void *, uint32_t baudrate);
 struct link_device {
   check_free_space_t check_free_space;  ///< check if transmit buffer is not full
   put_byte_t put_byte;                  ///< put one byte
+  put_buffer_t put_buffer;              ///< put several bytes from a buffer
   send_message_t send_message;          ///< send completed buffer
   char_available_t char_available;      ///< check if a new character is available
   get_byte_t get_byte;                  ///< get a new char

--- a/tools/generator/C/include_v1.0/pprzlink_device.h
+++ b/tools/generator/C/include_v1.0/pprzlink_device.h
@@ -36,7 +36,7 @@
  * they are used to cast the real functions with the correct type
  * to store in the device structure
  */
-typedef int (*check_free_space_t)(void *, long *, uint8_t);
+typedef int (*check_free_space_t)(void *, long *, uint16_t);
 typedef void (*put_byte_t)(void *, long, uint8_t);
 typedef void (*put_buffer_t)(void *, long, const uint8_t *, uint16_t);
 typedef void (*send_message_t)(void *, long);

--- a/tools/generator/C/include_v1.0/pprzlink_transport.h
+++ b/tools/generator/C/include_v1.0/pprzlink_transport.h
@@ -75,7 +75,7 @@ enum TransportDataFormat {
  * to store in the transport structure
  */
 typedef uint8_t (*size_of_t)(void *, uint8_t);
-typedef int (*check_available_space_t)(void *, struct link_device *, long *, uint8_t);
+typedef int (*check_available_space_t)(void *, struct link_device *, long *, uint16_t);
 typedef void (*put_bytes_t)(void *, struct link_device *, long, enum TransportDataType, enum TransportDataFormat,
                             const void *, uint16_t);
 typedef void (*put_named_byte_t)(void *, struct link_device *, long, enum TransportDataType, enum TransportDataFormat,

--- a/tools/generator/C/include_v1.0/pprzlink_transport.h
+++ b/tools/generator/C/include_v1.0/pprzlink_transport.h
@@ -75,13 +75,13 @@ enum TransportDataFormat {
  * to store in the transport structure
  */
 typedef uint8_t (*size_of_t)(void *, uint8_t);
-typedef int (*check_available_space_t)(void *, struct link_device *, uint8_t);
-typedef void (*put_bytes_t)(void *, struct link_device *, enum TransportDataType, enum TransportDataFormat, uint8_t,
-                            const void *);
-typedef void (*put_named_byte_t)(void *, struct link_device *, enum TransportDataType, enum TransportDataFormat,
+typedef int (*check_available_space_t)(void *, struct link_device *, long *, uint8_t);
+typedef void (*put_bytes_t)(void *, struct link_device *, long, enum TransportDataType, enum TransportDataFormat,
+                            const void *, uint16_t);
+typedef void (*put_named_byte_t)(void *, struct link_device *, long, enum TransportDataType, enum TransportDataFormat,
                                  uint8_t, const char *);
-typedef void (*start_message_t)(void *, struct link_device *, uint8_t);
-typedef void (*end_message_t)(void *, struct link_device *);
+typedef void (*start_message_t)(void *, struct link_device *, long, uint8_t);
+typedef void (*end_message_t)(void *, struct link_device *, long);
 typedef void (*overrun_t)(void *, struct link_device *);
 typedef void (*count_bytes_t)(void *, struct link_device *, uint8_t);
 

--- a/tools/generator/gen_messages_c.py
+++ b/tools/generator/gen_messages_c.py
@@ -51,13 +51,14 @@ ${{message:#define DL_${msg_name} ${id}
 ${{message:
 #define DOWNLINK_SEND_${msg_name}(_trans, _dev${{fields:, ${attrib_macro}}}) pprz_msg_send_${msg_name}(&((_trans).trans_tx), &((_dev).device), AC_ID${{fields:, ${attrib_macro}}})
 static inline void pprz_msg_send_${msg_name}(struct transport_tx *trans, struct link_device *dev, uint8_t ac_id${{fields:, ${attrib_fun}}}) {
-  if (trans->check_available_space(trans->impl, dev, trans->size_of(trans->impl, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */))) {
+  long fd = 0; /* can be an address, an index, a file descriptor, ... */
+  if (trans->check_available_space(trans->impl, dev, &fd, trans->size_of(trans->impl, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */))) {
     trans->count_bytes(trans->impl, dev, trans->size_of(trans->impl, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */));
-    trans->start_message(trans->impl, dev, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */);
-    trans->put_bytes(trans->impl, dev, DL_TYPE_UINT8, DL_FORMAT_SCALAR, 1, &ac_id);
-    trans->put_named_byte(trans->impl, dev, DL_TYPE_UINT8, DL_FORMAT_SCALAR, DL_${msg_name}, "${msg_name}");
-    ${{fields:${array_byte}trans->put_bytes(trans->impl, dev, DL_TYPE_${type_upper}, ${dl_format}, ${length}, (void *) _${field_name});
-    }}trans->end_message(trans->impl, dev);
+    trans->start_message(trans->impl, dev, fd, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */);
+    trans->put_bytes(trans->impl, dev, fd, DL_TYPE_UINT8, DL_FORMAT_SCALAR, &ac_id, 1);
+    trans->put_named_byte(trans->impl, dev, fd, DL_TYPE_UINT8, DL_FORMAT_SCALAR, DL_${msg_name}, "${msg_name}");
+    ${{fields:${array_byte}trans->put_bytes(trans->impl, dev, fd, DL_TYPE_${type_upper}, ${dl_format}, (void *) _${field_name}, ${length});
+    }}trans->end_message(trans->impl, dev, fd);
   } else
     trans->overrun(trans->impl, dev);
 }
@@ -117,7 +118,7 @@ def generate(output, xml):
                 f.attrib_macro = 'nb_%s, %s' % (f.field_name, f.field_name)
                 f.attrib_fun = 'uint8_t nb_%s, %s *_%s' % (f.field_name, f.type, f.field_name)
                 f.attrib_fun_unused = 'uint8_t nb_%s __attribute__((unused)), %s *_%s __attribute__((unused))' % (f.field_name, f.type, f.field_name)
-                f.array_byte = 'trans->put_bytes(trans->impl, dev, DL_TYPE_ARRAY_LENGTH, DL_FORMAT_SCALAR, 1, (void *) &nb_%s);\n    ' % f.field_name
+                f.array_byte = 'trans->put_bytes(trans->impl, dev, fd, DL_TYPE_ARRAY_LENGTH, DL_FORMAT_SCALAR, (void *) &nb_%s, 1);\n    ' % f.field_name
                 f.read_type = f.type+'_array'
                 if (offset + 1) % min(4, int(f.type_length)) == 0: # data are aligned
                     f.read_array_byte = '#define DL_%s_%s_length(_payload) _PPRZ_VAL_uint8_t(_payload, %d)\n' % (m.msg_name, f.field_name, offset)


### PR DESCRIPTION
this can be used to pass an address, an index or some file descriptor in
order to handle message queues

a put_buffer function is also added to the device for more efficient
sending