### PR TITLE
[python] move serial/ivy_msg_interface to pprzlink module

### DIFF
--- a/doc/python/ivy.rst
+++ b/doc/python/ivy.rst
@@ -1,5 +1,5 @@
 Ivy Interface
 =============
 
-.. autoclass:: ivy_msg_interface.IvyMessagesInterface
+.. autoclass:: pprzlink.ivy_msg_interface.IvyMessagesInterface
 	:members:

--- a/doc/python/serial.rst
+++ b/doc/python/serial.rst
@@ -1,5 +1,5 @@
 Serial Interface
 ================
 
-.. autoclass:: serial_msg_interface.SerialMessagesInterface
+.. autoclass:: pprzlink.serial_msg_interface.SerialMessagesInterface
 	:members:

--- a/lib/v1.0/python/pprzlink/ivy_msg_interface.py
+++ b/lib/v1.0/python/pprzlink/ivy_msg_interface.py
@@ -8,14 +8,8 @@ import sys
 import re
 import platform
 
-# if PPRZLINK_LIB not set, then assume the tree containing this
-# file is a reasonable substitute
-PPRZLINK_LIB = os.getenv("PPRZLINK_LIB", os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                                                    '../../../')))
-sys.path.append(PPRZLINK_LIB + "/lib/v1.0/python")
-
-from pprzlink.message import PprzMessage
-from pprzlink import messages_xml_map
+from .message import PprzMessage
+from . import messages_xml_map
 
 
 if os.getenv('IVY_BUS') is not None:
@@ -108,7 +102,7 @@ class IvyMessagesInterface(object):
         """
         Parse an Ivy message into a PprzMessage.
         Basically parts/args in string are separated by space, but char array can also contain a space:
-        |f,o,o, ,b,a,r| in old format or "foo bar" in new format
+        ``|f,o,o, ,b,a,r|`` in old format or ``"foo bar"`` in new format
 
         :param callback: function to call with ac_id and parsed PprzMessage as params
         :param ivy_msg: Ivy message string to parse into PprzMessage

--- a/lib/v1.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v1.0/python/pprzlink/messages_xml_map.py
@@ -4,11 +4,14 @@ from __future__ import absolute_import, print_function
 
 import os
 
-# if PAPARAZZI_HOME not set, then assume the tree containing this
-# file is a reasonable substitute
-PPRZ_HOME = os.getenv("PAPARAZZI_HOME", os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                                                      '../../../../../../..')))
-default_messages_file = '%s/var/messages.xml' % PPRZ_HOME
+# if PAPARAZZI_HOME is set use $PAPARAZZI_HOME/var/messages.xml
+# else use messages.xml from pprzlink message_definitions directly
+PPRZ_HOME = os.getenv("PAPARAZZI_HOME")
+if PPRZ_HOME is not None:
+    default_messages_file = '%s/var/messages.xml' % PPRZ_HOME
+else:
+    default_messages_file = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                                          "../../../../message_definitions/v1.0/messages.xml"))
 
 message_dictionary = {}
 message_dictionary_types = {}

--- a/lib/v1.0/python/pprzlink/serial_msg_interface.py
+++ b/lib/v1.0/python/pprzlink/serial_msg_interface.py
@@ -2,18 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 import serial
-import os
-import sys
 
-# if PPRZLINK_LIB not set, then assume the tree containing this
-# file is a reasonable substitute
-PPRZ_SRC = os.getenv("PPRZLINK_LIB", os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                                                    '../../../')))
-sys.path.append(PPRZ_SRC + "/lib/v1.0/python")
-
-from pprzlink.message import PprzMessage
-from pprzlink.pprz_transport import PprzTransport
-import pprzlink.messages_xml_map
+from .message import PprzMessage
+from .pprz_transport import PprzTransport
 
 
 class SerialMessagesInterface(threading.Thread):
@@ -73,6 +64,7 @@ class SerialMessagesInterface(threading.Thread):
 def test():
     import time
     import argparse
+    from . import messages_xml_map
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-f", "--file", help="path to messages.xml file")
@@ -80,7 +72,7 @@ def test():
     parser.add_argument("-d", "--device", help="device name", dest='dev', default='/dev/ttyUSB0')
     parser.add_argument("-b", "--baudrate", help="baudrate", dest='baud', default=115200, type=int)
     args = parser.parse_args()
-    pprzlink.messages_xml_map.parse_messages(args.file)
+    messages_xml_map.parse_messages(args.file)
     serial_interface = SerialMessagesInterface(lambda s, m: print("new message from %i: %s" % (s, m)), device=args.dev,
                                                baudrate=args.baud, msg_class=args.msg_class, verbose=True)
 


### PR DESCRIPTION
and use proper relative imports instead of PPRZLINK_LIB env var