### PR TITLE
[pprz] Update protocol parser with additional parser

### DIFF
--- a/lib/v1.0/C/pprz_transport.c
+++ b/lib/v1.0/C/pprz_transport.c
@@ -182,12 +182,17 @@ restart:
 
 
 /** Parsing a frame data and copy the payload to the datalink buffer */
-void pprz_check_and_parse(struct link_device *dev, struct pprz_transport *trans, uint8_t *buf, bool *msg_available)
+void pprz_check_and_parse(struct link_device *dev, struct pprz_transport *trans, uint8_t *buf, bool *msg_available, pprz_parse_byte parse_byte)
 {
   uint8_t i;
   if (dev->char_available(dev->periph)) {
     while (dev->char_available(dev->periph) && !trans->trans_rx.msg_received) {
-      parse_pprz(trans, dev->get_byte(dev->periph));
+      uint8_t c = dev->get_byte(dev->periph);
+      parse_pprz(trans, c);
+
+      if(parse_byte != NULL) {
+        (*parse_byte)(c);
+      }
     }
     if (trans->trans_rx.msg_received) {
       for (i = 0; i < trans->trans_rx.payload_len; i++) {

--- a/lib/v1.0/C/pprz_transport.h
+++ b/lib/v1.0/C/pprz_transport.h
@@ -68,8 +68,11 @@ struct pprz_transport {
 // Init function
 extern void pprz_transport_init(struct pprz_transport *t);
 
+// Optional extra parse
+typedef void (*pprz_parse_byte)(uint8_t c);
+
 // Checking new data and parsing
-extern void pprz_check_and_parse(struct link_device *dev, struct pprz_transport *trans, uint8_t *buf, bool *msg_available);
+extern void pprz_check_and_parse(struct link_device *dev, struct pprz_transport *trans, uint8_t *buf, bool *msg_available, pprz_parse_byte parse_byte);
 
 // Parsing function, only needed for modules doing their own parsing
 // without using the pprz_check_and_parse function


### PR DESCRIPTION
Add an optional extra parser for the bytes.
This is useful for example for `intermcu`, where also bytes from the original PX4 firmware could come in.