### PR TITLE
added index to mission messages

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -696,6 +696,7 @@
   <message name="MISSION_STATUS" id="79">
     <field name="remaining_time" type="float"/>
     <field name="task_list" type="uint8[]"/>
+    <field name="index_list" type="uint8[]"/>
   </message>
 
   <message name="CROSS_TRACK_ERROR" id="80">
@@ -2379,6 +2380,7 @@
     <field name="wp_north" type="float" unit="m"/>
     <field name="wp_alt" type="float" unit="m">altitude above geoid (MSL)</field>
     <field name="duration" type="float" unit="s"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="MISSION_GOTO_WP_LLA" id="21" link="forwarded">
@@ -2388,6 +2390,7 @@
     <field name="wp_lon" type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
     <field name="wp_alt" type="int32" unit="mm" alt_unit="m">altitude above geoid (MSL)</field>
     <field name="duration" type="float" unit="s"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="MISSION_CIRCLE" id="22" link="forwarded">
@@ -2398,6 +2401,7 @@
     <field name="center_alt" type="float" unit="m">altitude above geoid (MSL)</field>
     <field name="radius" type="float" unit="m"/>
     <field name="duration" type="float" unit="s"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="MISSION_CIRCLE_LLA" id="23" link="forwarded">
@@ -2408,6 +2412,7 @@
     <field name="center_alt" type="int32" unit="mm" alt_unit="m">altitude above geoid (MSL)</field>
     <field name="radius" type="float" unit="m"/>
     <field name="duration" type="float" unit="s"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="MISSION_SEGMENT" id="24" link="forwarded">
@@ -2419,6 +2424,7 @@
     <field name="segment_north_2" type="float" unit="m"/>
     <field name="segment_alt" type="float" unit="m">altitude above geoid (MSL)</field>
     <field name="duration" type="float" unit="s"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="MISSION_SEGMENT_LLA" id="25" link="forwarded">
@@ -2430,6 +2436,7 @@
     <field name="segment_lon_2" type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
     <field name="segment_alt" type="int32" unit="mm" alt_unit="m">altitude above geoid (MSL)</field>
     <field name="duration" type="float" unit="s"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="MISSION_PATH" id="26" link="forwarded">
@@ -2448,6 +2455,7 @@
     <field name="path_alt" type="float" unit="m">altitude above geoid (MSL)</field>
     <field name="duration" type="float" unit="s"/>
     <field name="nb" type="uint8"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="MISSION_PATH_LLA" id="27" link="forwarded">
@@ -2466,6 +2474,7 @@
     <field name="path_alt" type="int32" unit="mm" alt_unit="m">altitude above geoid (MSL)</field>
     <field name="duration" type="float" unit="s"/>
     <field name="nb" type="uint8"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="MISSION_SURVEY" id="28" link="forwarded">
@@ -2477,6 +2486,7 @@
     <field name="survey_north_2" type="float" unit="m"/>
     <field name="survey_alt" type="float" unit="m">altitude above geoid (MSL)</field>
     <field name="duration" type="float" unit="s"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="MISSION_SURVEY_LLA" id="29" link="forwarded">
@@ -2488,6 +2498,7 @@
     <field name="survey_lon_2" type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
     <field name="survey_alt" type="int32" unit="mm" alt_unit="m">altitude above geoid (MSL)</field>
     <field name="duration" type="float" unit="s"/>
+    <field name="index" type="uint8"/>
   </message>
 
   <message name="GOTO_MISSION" id="30" link="forwarded">

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -695,7 +695,6 @@
 
   <message name="MISSION_STATUS" id="79">
     <field name="remaining_time" type="float"/>
-    <field name="task_list" type="uint8[]"/>
     <field name="index_list" type="uint8[]"/>
   </message>
 


### PR DESCRIPTION
It would be nice to associate a specific id to each mission that is sent to the mission module.
Currently all we get back is an array of the type of missions in the queue.

By associating an ID number there is no confusion as to what missions are in the queue.

paparazzi/paparazzi#1918
