### PR TITLE
Camera payload messages

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -809,7 +809,7 @@
 
     <message name="CAMERA_PAYLOAD" id="111">
       <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
-      <field name="used_memory" type="uint8" unit="%">Percentage of used memory of the payload computer (rounded up to whole percent)</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer (rounded up to whole percent)</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
       <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
       <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
@@ -949,6 +949,7 @@
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
       <field name="snapshot_valid" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
       <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
+      <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature (NaN if not measured</field>
     </message>
 
     <message name="TIMESTAMP" id="129">

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2206,6 +2206,31 @@
       <field name="ac_id" type="uint8"/>
     </message>
 
+    <message name="COPILOT_STAT" id="33">
+      <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
+      <field name="status" type="uint8" values="UNKNOWN|RUNNING|FAULT">Mission computer status</field>
+      <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
+    </message>
+
+    <message name="CAMERA_PAYL" id="34">
+      <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer rounded up to whole percent</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer rounded up to whole percent</field>
+      <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
+      <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
+    </message>
+
+    <message name="CAMERA_SHOT" id="35">
+      <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
+      <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
+      <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
+      <field name="snapshot_valid" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
+      <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature, NaN if not measured</field>
+      <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature, NaN if not measured</field>
+    </message>
+
     <message name="GUIDED_SETPOINT_NED" id="40" link="forwarded">
       <description>
         Set vehicle position or velocity in NED.

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -945,9 +945,9 @@
 
     <message name="CAMERA_SNAPSHOT" id="128">
       <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
-      <field anme="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
+      <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
-      <field name="valid_snapshot" type="bool">Flag checking whether the last snapshot was valid</field>
+      <field name="valid_snapshot" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
       <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
     </message>
 

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -915,7 +915,13 @@
       <field name="climb" type="float"/>
     </message>
 
-    <!-- 125 is free -->
+    <message name="COPILOT_STATUS" id="125">
+      <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
+      <field name="status" type="uint8" values="UNKNOWN|RUNNING|FAULT">Mission computer status</field>
+      <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
+    </message>
 
     <message name="TEMP_TCOUPLE" id="126">
       <field name="fval0" type="float"/>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -809,8 +809,8 @@
 
     <message name="CAMERA_PAYLOAD" id="111">
       <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
-      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer (rounded up to whole percent)</field>
-      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer rounded up to whole percent</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer rounded up to whole percent</field>
       <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
       <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
     </message>
@@ -948,8 +948,8 @@
       <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
       <field name="snapshot_valid" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
-      <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
-      <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature (NaN if not measured</field>
+      <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature, NaN if not measured</field>
+      <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature, NaN if not measured</field>
     </message>
 
     <message name="TIMESTAMP" id="129">

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -947,7 +947,7 @@
       <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
       <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
-      <field name="valid_snapshot" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
+      <field name="snapshot_valid" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
       <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
     </message>
 

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -809,8 +809,8 @@
 
     <message name="CAMERA_PAYLOAD" id="111">
       <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
-      <field name="used_memory_percent" type="uint8" unit="%">Percentage of used memory of the payload computer (rounded up to whole percent)</field>
-      <field name="used_disk_percent" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory of the payload computer (rounded up to whole percent)</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
       <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
       <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
     </message>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -807,7 +807,13 @@
       <field name="itow" type="uint32" unit="ms">GPS time of week</field>
     </message>
 
-    <!-- 111 is free -->
+    <message name="CAMERA_PAYLOAD" id="111">
+      <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
+      <field name="used_memory_percent" type="uint8" unit="%">Percentage of used memory of the payload computer (rounded up to whole percent)</field>
+      <field name="used_disk_percent" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
+      <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
+      <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
+    </message>
 
     <message name="MOTOR_MIXING" id="112">
       <field name="values" type="int16[]" unit="none"/>
@@ -938,7 +944,11 @@
     </message>
 
     <message name="CAMERA_SNAPSHOT" id="128">
-      <field name="snapshot_image_number" type="uint16"/>
+      <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
+      <field anme="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
+      <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
+      <field name="valid_snapshot" type="bool">Flag checking whether the last snapshot was valid</field>
+      <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
     </message>
 
     <message name="TIMESTAMP" id="129">


### PR DESCRIPTION
Added a CAMERA_PAYLOAD message for payloads with multiple cameras and a payload computer.

Extended CAMERA_SNAPSHOT message to include additional information about each camera.

Hoping this will be a generic enough message format for other camera+computer payloads.

The extra overhead in CAMERA_SNAPSHOT hopefully won't be an issue, as the only place where this message was used in paparazzi was for ArDrone with telemetry over wifi.