### PR TITLE
Camera payload

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -809,7 +809,7 @@
 
     <message name="CAMERA_PAYLOAD" id="111">
       <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
-      <field name="used_memory" type="uint8" unit="%">Percentage of used memory of the payload computer (rounded up to whole percent)</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer (rounded up to whole percent)</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
       <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
       <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
@@ -949,6 +949,7 @@
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
       <field name="snapshot_valid" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
       <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
+      <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature (NaN if not measured</field>
     </message>
 
     <message name="TIMESTAMP" id="129">

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2206,6 +2206,31 @@
       <field name="ac_id" type="uint8"/>
     </message>
 
+    <message name="COPILOT_STAT" id="33">
+      <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
+      <field name="status" type="uint8" values="UNKNOWN|RUNNING|FAULT">Mission computer status</field>
+      <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
+    </message>
+
+    <message name="CAMERA_PAYL" id="34">
+      <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer rounded up to whole percent</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer rounded up to whole percent</field>
+      <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
+      <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
+    </message>
+
+    <message name="CAMERA_SHOT" id="35">
+      <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
+      <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
+      <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
+      <field name="snapshot_valid" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
+      <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature, NaN if not measured</field>
+      <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature, NaN if not measured</field>
+    </message>
+
     <message name="GUIDED_SETPOINT_NED" id="40" link="forwarded">
       <description>
         Set vehicle position or velocity in NED.

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2207,6 +2207,7 @@
     </message>
 
     <message name="COPILOT_STAT" id="33" link="forwarded">
+      <field name="ac_id" type="uint8"/>
       <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
@@ -2215,6 +2216,7 @@
     </message>
 
     <message name="CAMERA_PAYL" id="34" link="forwarded">
+      <field name="ac_id" type="uint8"/>
       <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer rounded up to whole percent</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer rounded up to whole percent</field>
@@ -2223,6 +2225,7 @@
     </message>
 
     <message name="CAMERA_SHOT" id="35" link="forwarded">
+      <field name="ac_id" type="uint8"/>
       <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
       <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2205,7 +2205,7 @@
       <field name="ac_id" type="uint8"/>
     </message>
 
-    <message name="COPILOT_STAT" id="33" link="forwarded">
+    <message name="COPILOT_STATUS_DL" id="33" link="forwarded">
       <field name="ac_id" type="uint8"/>
       <field name="timestamp" type="float" unit="s">Mission computer seconds since startup</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
@@ -2214,7 +2214,7 @@
       <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
     </message>
 
-    <message name="CAMERA_PAYL" id="34" link="forwarded">
+    <message name="CAMERA_PAYLOAD_DL" id="34" link="forwarded">
       <field name="ac_id" type="uint8"/>
       <field name="timestamp" type="float" unit="s">Payload computer seconds sice startup</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer rounded up to whole percent</field>
@@ -2223,7 +2223,7 @@
       <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
     </message>
 
-    <message name="CAMERA_SHOT" id="35" link="forwarded">
+    <message name="CAMERA_SNAPSHOT_DL" id="35" link="forwarded">
       <field name="ac_id" type="uint8"/>
       <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
       <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -945,9 +945,9 @@
 
     <message name="CAMERA_SNAPSHOT" id="128">
       <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
-      <field anme="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
+      <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
-      <field name="valid_snapshot" type="bool">Flag checking whether the last snapshot was valid</field>
+      <field name="valid_snapshot" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
       <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
     </message>
 

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -915,7 +915,13 @@
       <field name="climb" type="float"/>
     </message>
 
-    <!-- 125 is free -->
+    <message name="COPILOT_STATUS" id="125">
+      <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
+      <field name="status" type="uint8" values="UNKNOWN|RUNNING|FAULT">Mission computer status</field>
+      <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
+    </message>
 
     <message name="TEMP_TCOUPLE" id="126">
       <field name="fval0" type="float"/>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2206,7 +2206,7 @@
       <field name="ac_id" type="uint8"/>
     </message>
 
-    <message name="COPILOT_STAT" id="33">
+    <message name="COPILOT_STAT" id="33" link="forwarded">
       <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
@@ -2214,7 +2214,7 @@
       <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
     </message>
 
-    <message name="CAMERA_PAYL" id="34">
+    <message name="CAMERA_PAYL" id="34" link="forwarded">
       <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer rounded up to whole percent</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer rounded up to whole percent</field>
@@ -2222,7 +2222,7 @@
       <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
     </message>
 
-    <message name="CAMERA_SHOT" id="35">
+    <message name="CAMERA_SHOT" id="35" link="forwarded">
       <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
       <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -809,8 +809,8 @@
 
     <message name="CAMERA_PAYLOAD" id="111">
       <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
-      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer (rounded up to whole percent)</field>
-      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer rounded up to whole percent</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer rounded up to whole percent</field>
       <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
       <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
     </message>
@@ -948,8 +948,8 @@
       <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
       <field name="snapshot_valid" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
-      <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
-      <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature (NaN if not measured</field>
+      <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature, NaN if not measured</field>
+      <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature, NaN if not measured</field>
     </message>
 
     <message name="TIMESTAMP" id="129">

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -947,7 +947,7 @@
       <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
       <field name="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
       <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
-      <field name="valid_snapshot" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
+      <field name="snapshot_valid" type="uint8" unit="bool">Flag checking whether the last snapshot was valid</field>
       <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
     </message>
 

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -809,8 +809,8 @@
 
     <message name="CAMERA_PAYLOAD" id="111">
       <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
-      <field name="used_memory_percent" type="uint8" unit="%">Percentage of used memory of the payload computer (rounded up to whole percent)</field>
-      <field name="used_disk_percent" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory of the payload computer (rounded up to whole percent)</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
       <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
       <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
     </message>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2234,15 +2234,6 @@
       <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature, NaN if not measured</field>
     </message>
 
-    <message name="COPILOT_STAT" id="36" link="forwarded">
-      <field name="ac_id" type="uint8"/>
-      <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
-      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
-      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
-      <field name="status" type="uint8" values="UNKNOWN|RUNNING|FAULT">Mission computer status</field>
-      <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
-    </message>
-
     <message name="GUIDED_SETPOINT_NED" id="40" link="forwarded">
       <description>
         Set vehicle position or velocity in NED.

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -808,7 +808,7 @@
     </message>
 
     <message name="CAMERA_PAYLOAD" id="111">
-      <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
+      <field name="timestamp" type="float" unit="s">Payload computer seconds since startup</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer rounded up to whole percent</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer rounded up to whole percent</field>
       <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
@@ -916,10 +916,10 @@
     </message>
 
     <message name="COPILOT_STATUS" id="125">
-      <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
+      <field name="timestamp" type="float" unit="s">Mission computer seconds since startup</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
-      <field name="status" type="uint8" values="UNKNOWN|RUNNING|FAULT">Mission computer status</field>
+      <field name="status" type="uint8" values="UNKNOWN|INIT|LOGGING|FAULT">Mission computer status</field>
       <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
     </message>
 
@@ -1704,9 +1704,8 @@
       <field name="id" type="uint8"/>
     </message>
 
-  <!-- Do we really need this? It is used in test_radio_control.c and test_adc.c only -->
     <message name="TIME" id="227">
-      <field name="t" type="uint32"/>
+      <field name="t" type="uint32">an integral value representing the number of seconds elapsed since 00:00 hours, Jan 1, 1970 UTC</field>
     </message>
 
     <message name="OPTIC_FLOW_EST" id="228">
@@ -2208,16 +2207,16 @@
 
     <message name="COPILOT_STAT" id="33" link="forwarded">
       <field name="ac_id" type="uint8"/>
-      <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
+      <field name="timestamp" type="float" unit="s">Mission computer seconds since startup</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
-      <field name="status" type="uint8" values="UNKNOWN|RUNNING|FAULT">Mission computer status</field>
+      <field name="status" type="uint8" values="UNKNOWN|INIT|LOGGING|FAULT">Mission computer status</field>
       <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
     </message>
 
     <message name="CAMERA_PAYL" id="34" link="forwarded">
       <field name="ac_id" type="uint8"/>
-      <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
+      <field name="timestamp" type="float" unit="s">Payload computer seconds sice startup</field>
       <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the payload computer rounded up to whole percent</field>
       <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the payload computer rounded up to whole percent</field>
       <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -807,7 +807,13 @@
       <field name="itow" type="uint32" unit="ms">GPS time of week</field>
     </message>
 
-    <!-- 111 is free -->
+    <message name="CAMERA_PAYLOAD" id="111">
+      <field name="timestamp" type="float" unit="s">Payload computer timestamp</field>
+      <field name="used_memory_percent" type="uint8" unit="%">Percentage of used memory of the payload computer (rounded up to whole percent)</field>
+      <field name="used_disk_percent" type="uint8" unit="%">Percentage of used disk of the payload computer (rounded up to whole percent)</field>
+      <field name="door_status" type="uint8" values="UNKNOWN|CLOSE|OPEN">Payload door open/close</field>
+      <field name="error_code" type="uint8" values="NONE|CAMERA_ERR|DOOR_ERR">Error codes of the payload</field>
+    </message>
 
     <message name="MOTOR_MIXING" id="112">
       <field name="values" type="int16[]" unit="none"/>
@@ -938,7 +944,11 @@
     </message>
 
     <message name="CAMERA_SNAPSHOT" id="128">
-      <field name="snapshot_image_number" type="uint16"/>
+      <field name="camera_id" type="uint16">Unique camera ID - consists of make,model and camera index</field>
+      <field anme="camera_state" type="uint8" values="UNKNOWN|OK|ERROR">State of the given camera</field>
+      <field name="snapshot_image_number" type="uint16">Snapshot number in sequence</field>
+      <field name="valid_snapshot" type="bool">Flag checking whether the last snapshot was valid</field>
+      <field name="lens_temp" type="float" unit="deg_celsius" format="%.2f">Lens temperature (NaN if not measured</field>
     </message>
 
     <message name="TIMESTAMP" id="129">

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2234,6 +2234,15 @@
       <field name="array_temp" type="float" unit="deg_celsius" format="%.2f">Imager sensor temperature, NaN if not measured</field>
     </message>
 
+    <message name="COPILOT_STAT" id="36" link="forwarded">
+      <field name="ac_id" type="uint8"/>
+      <field name="timestamp" type="float" unit="s">Mission computer timestamp</field>
+      <field name="used_memory" type="uint8" unit="%">Percentage of used memory (RAM) of the mission computer rounded up to whole percent</field>
+      <field name="used_disk" type="uint8" unit="%">Percentage of used disk of the mission computer rounded up to whole percent</field>
+      <field name="status" type="uint8" values="UNKNOWN|RUNNING|FAULT">Mission computer status</field>
+      <field name="error_code" type="uint8" values="NONE|IO_ERROR">Error codes of the mission computer</field>
+    </message>
+
     <message name="GUIDED_SETPOINT_NED" id="40" link="forwarded">
       <description>
         Set vehicle position or velocity in NED.


### PR DESCRIPTION
Added messages for Mission computer status, payload camera status and payload computer status.
Also added messages for forwarding from the mission computer through the autopilot to the GCS.
More information and description of the system here https://wiki.paparazziuav.org/wiki/Mission_computer