### PR TITLE
Add stereocam messages

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -1725,9 +1725,11 @@
     </message>
 
     <message name="STEREO_IMG" id="229">
-      <field name="frequency" type="uint8"/>
-      <field name="data_size" type="uint8"/>
-      <field name="imageBuffer" type="uint8[]"/>
+      <field name="type"       type="uint8" values="DIST_MATRIX|HISTOGRAM|DISPARITY_MAP|RAW"/>
+      <field name="width"      type="uint8"/>
+      <field name="height"     type="uint8"/>
+      <field name="package_nb" type="uint8"/>
+      <field name="image_data" type="uint8[]"/>
     </message>
 
     <!-- 230 is free -->
@@ -2826,6 +2828,46 @@
       <field name="numsv"   type="uint8"/>
       <field name="fix"     type="uint8" values="NONE|NA|2D|3D|DGPS|RTK"/>
     </message>
+    
+    
+    <message name="STEREOCAM_ARRAY" id="80">
+      <description>Raw data fromt the stereocamera. Type defines what kind of data it is. This can be raw image, disparity map, obstacle histogram, ect.</description>
+      <field name="type" type="uint8" values="DIST_MATRIX|HISTOGRAM|DISPARITY_MAP|RAW"/>
+      <field name="width" type="uint8">array size parameters</field>
+      <field name="height" type="uint8"/>
+      <field name="package_nb" type="uint8">If the data being sent is too large for one message (e.g when sending a full image) this will indicate which package of the total data is contained in this message</field>
+      <field name="image_data" type="uint8[]"/>
+    </message>
+    
+    <message name="STEREOCAM_VELOCITY" id="81">
+      <description>Velocity measured using optical flow and stereovision. All parameters are in the camera frame</description>
+      <field name="resolution" type="uint8">Resolution of the vel and pos messages</field>
+      <field name="dt_frame"   type="uint8">Time difference to previous frame</field>
+      <field name="dt"         type="uint8">Time difference to previous message, not strictly required</field>
+      <field name="velx"       type="int16" unit="m/s">Velocity estimaed using stereo edgeflow</field>
+      <field name="vely"       type="int16" unit="m/s"/>
+      <field name="velz"       type="int16" unit="m/s"/>
+      <field name="dposx"      type="int16" unit="m">Distance traveled since the last message</field>
+      <field name="dposy"      type="int16" unit="m"/>
+      <field name="dposz"      type="int16" unit="m"/>
+      <field name="vRMS"       type="uint8">RMS of the velocity estimate</field>
+      <field name="posRMS"     type="uint8">RMS of the position</field>
+      <field name="avg_dist"   type="uint16">Average distance to scene</field>
+    </message>
+    
+    <message name="STEREOCAM_STATE" id="82">
+      <description>Estimated state of the camera. As the stereocamera has no inertial sensors, this data should be sent to the stereocamera to enable onboard derotation of the optical flow</description>
+      <field name="phi" 	type="float" unit="rad">Pitch, roll and yaw angles of the camera</field>
+      <field name="theta"   type="float" unit="rad"/>
+      <field name="psi"     type="float" unit="rad"/>
+      <field name="agl"     type="float" unit="m">Altitude above the ground. If not looking down, set to 0</field>
+    </message>
+    
+    <message name="STEREOCAM_FOLLOW_ME" id="83">
+      <field name="headingToFollow" 	type="uint8"/>
+      <field name="heightObject"   		type="uint8"/>
+      <field name="distanceToObject"    type="uint8"/>
+    </message>
 
     <message name="IMCU_DATALINK" id="113">
      <description>Forward FBW datalink to AP</description>
@@ -2846,5 +2888,5 @@
     </message>
 
   </msg_class>
-
+  
 </protocol>


### PR DESCRIPTION
This adds some initial messages for communicating with the stereocamera. This is added to the intermcu messages for now as there are only 4 messages. In the future, as we add more messages we will likely move these to their own message class.