### PR TITLE
Add optional priority attribude for messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@
 /build
 /var
 /.idea/
+
+# Eclipse IDE settings files
+.cproject
+.project
+.pydevproject
+.settings/*
+

--- a/lib/v1.0/C/pprz_transport.c
+++ b/lib/v1.0/C/pprz_transport.c
@@ -55,6 +55,9 @@ static void accumulate_checksum(struct pprz_transport *trans, const uint8_t byte
   trans->ck_b_tx += trans->ck_a_tx;
 }
 
+static void put_priority(struct spprz_transport *trans __attribute__((unused)), struct link_device *dev __attribute__((unused)),
+                         long fd __attribute__((unused)), uint8_t prio __attribute__((unused))) {}
+
 static void put_bytes(struct pprz_transport *trans, struct link_device *dev, long fd,
                       enum TransportDataType type __attribute__((unused)), enum TransportDataFormat format __attribute__((unused)),
                       const void *bytes, uint16_t len)
@@ -127,6 +130,7 @@ void pprz_transport_init(struct pprz_transport *t)
   t->trans_tx.overrun = (overrun_t) overrun;
   t->trans_tx.count_bytes = (count_bytes_t) count_bytes;
   t->trans_tx.impl = (void *)(t);
+  t->trans_tx.put_priority = (put_priority_t) put_priority;
 }
 
 

--- a/lib/v1.0/C/pprz_transport.c
+++ b/lib/v1.0/C/pprz_transport.c
@@ -55,7 +55,7 @@ static void accumulate_checksum(struct pprz_transport *trans, const uint8_t byte
   trans->ck_b_tx += trans->ck_a_tx;
 }
 
-static void put_priority(struct spprz_transport *trans __attribute__((unused)), struct link_device *dev __attribute__((unused)),
+static void put_priority(struct pprz_transport *trans __attribute__((unused)), struct link_device *dev __attribute__((unused)),
                          long fd __attribute__((unused)), uint8_t prio __attribute__((unused))) {}
 
 static void put_bytes(struct pprz_transport *trans, struct link_device *dev, long fd,

--- a/lib/v2.0/C/pprz_transport.c
+++ b/lib/v2.0/C/pprz_transport.c
@@ -59,8 +59,8 @@ static void accumulate_checksum(struct pprz_transport *trans, const uint8_t byte
   trans->ck_b_tx += trans->ck_a_tx;
 }
 
-static void put_priority(struct spprz_transport *trans __attribute__((unused)), struct link_device *dev __attribute__((unused)),
-                         long fd __attribute__((unused)), uint8_t prio __attribute__((unused))) {}
+static void put_priority(struct pprzlink_msg *msg __attribute__((unused)), long fd __attribute__((unused)),
+                         uint8_t prio __attribute__((unused))) {}
 
 static void put_bytes(struct pprzlink_msg *msg, long fd,
                       enum TransportDataType type __attribute__((unused)), enum TransportDataFormat format __attribute__((unused)),

--- a/lib/v2.0/C/pprz_transport.c
+++ b/lib/v2.0/C/pprz_transport.c
@@ -59,6 +59,9 @@ static void accumulate_checksum(struct pprz_transport *trans, const uint8_t byte
   trans->ck_b_tx += trans->ck_a_tx;
 }
 
+static void put_priority(struct spprz_transport *trans __attribute__((unused)), struct link_device *dev __attribute__((unused)),
+                         long fd __attribute__((unused)), uint8_t prio __attribute__((unused))) {}
+
 static void put_bytes(struct pprzlink_msg *msg, long fd,
                       enum TransportDataType type __attribute__((unused)), enum TransportDataFormat format __attribute__((unused)),
                       const void *bytes, uint16_t len)
@@ -130,6 +133,7 @@ void pprz_transport_init(struct pprz_transport *t)
   t->trans_tx.overrun = (overrun_t) overrun;
   t->trans_tx.count_bytes = (count_bytes_t) count_bytes;
   t->trans_tx.impl = (void *)(t);
+  t->trans_tx.put_priority = (put_priority_t) put_priority;
 }
 
 

--- a/message_definitions/v1.0/messages.dtd
+++ b/message_definitions/v1.0/messages.dtd
@@ -12,6 +12,7 @@
   name CDATA #REQUIRED
   id   CDATA #REQUIRED
   link CDATA #IMPLIED
+  priority CDATA #IMPLIED
 >
 
 <!ELEMENT description (#PCDATA)>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -4,7 +4,7 @@
  <!-- messages from modem or sim to server -->
  <msg_class name="telemetry" id="1">
 
-    <message name="AUTOPILOT_VERSION" id="1">
+    <message name="AUTOPILOT_VERSION" id="1" priority="2">
       <field name="version" type="uint32">version encoded as: MAJOR * 10000 + MINOR * 100 + PATCH</field>
       <field name="desc" type="char[]">version description as string from paparazzi_version</field>
     </message>
@@ -14,7 +14,7 @@
       <field name="md5sum" type="uint8[]"/>
     </message>
 
-    <message name="PONG" id="3" priority="1">
+    <message name="PONG" id="3" priority="2">
      <description>Answer to PING datalink message, to measure latencies</description>
     </message>
 

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -4,7 +4,7 @@
  <!-- messages from modem or sim to server -->
  <msg_class name="telemetry" id="1">
 
-    <message name="AUTOPILOT_VERSION" id="1" priority="2">
+    <message name="AUTOPILOT_VERSION" id="1">
       <field name="version" type="uint32">version encoded as: MAJOR * 10000 + MINOR * 100 + PATCH</field>
       <field name="desc" type="char[]">version description as string from paparazzi_version</field>
     </message>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -14,7 +14,7 @@
       <field name="md5sum" type="uint8[]"/>
     </message>
 
-    <message name="PONG" id="3">
+    <message name="PONG" id="3" priority="1">
      <description>Answer to PING datalink message, to measure latencies</description>
     </message>
 
@@ -2052,7 +2052,7 @@
       <field name="ac_id" type="uint8"/>
     </message>
 
-    <message name="PING" id="8"/>
+    <message name="PING" id="8" priority="2"/>
 
     <message name="FORMATION_SLOT" id="9" link="broadcasted">
       <field name="ac_id" type="uint8"/>
@@ -2307,13 +2307,13 @@
       <field name="cycle_time" type="uint32" unit="ms"/>
     </message>
 
-    <message name="RC_3CH" id="51" link="broadcasted">
+    <message name="RC_3CH" id="51" link="broadcasted" priority="2">
       <field name="throttle_mode" type="uint8" unit="byte_mask"/>
       <field name="roll"  type="int8"/>
       <field name="pitch" type="int8"/>
     </message>
 
-    <message name="RC_4CH" id="52" link="broadcasted">
+    <message name="RC_4CH" id="52" link="broadcasted" priority="2">
       <field name="ac_id"       type="uint8"/>
       <field name="mode"        type="uint8"/>
       <field name="throttle"    type="uint8"/>
@@ -2322,7 +2322,7 @@
       <field name="yaw"         type="int8"/>
     </message>
 
-    <message name="RC_5CH" id="53" link="broadcasted">
+    <message name="RC_5CH" id="53" link="broadcasted" priority="2">
       <field name="ac_id"       type="uint8"/>
       <field name="throttle"    type="uint8"/>
       <field name="roll"        type="int8"/>

--- a/message_definitions/v1.0/pprz_schema.xsd
+++ b/message_definitions/v1.0/pprz_schema.xsd
@@ -19,6 +19,7 @@
 <xs:attribute name="link" type="xs:string"/> <!-- message -->
 <xs:attribute name="format" type="xs:string"/> <!-- field -->
 <xs:attribute name="unit" type="xs:string"/> <!-- field -->
+<xs:attribute name="priority" type="xs:byte"/> <!-- field -->
 <xs:attribute name="alt_unit" type="xs:string"/> <!-- field -->
 <xs:attribute name="alt_unit_coef" type="xs:string"/> <!-- field (FIXME: should be decimal AND scientific notation, allow all strings as workaround for now -->
 <xs:attribute name="values" type="xs:string"/> <!-- field -->

--- a/message_definitions/v1.0/pprz_schema.xsd
+++ b/message_definitions/v1.0/pprz_schema.xsd
@@ -68,6 +68,7 @@
         <xs:attribute ref="name" use="required"/>
         <xs:attribute ref="id" use="required"/>
         <xs:attribute ref="link"/>
+        <xs:attribute ref="priority"/>
     </xs:complexType>
 </xs:element>
 

--- a/tools/generator/C/include_v1.0/pprzlink_transport.h
+++ b/tools/generator/C/include_v1.0/pprzlink_transport.h
@@ -88,6 +88,7 @@ typedef void (*start_message_t)(void *, struct link_device *, long, uint8_t);
 typedef void (*end_message_t)(void *, struct link_device *, long);
 typedef void (*overrun_t)(void *, struct link_device *);
 typedef void (*count_bytes_t)(void *, struct link_device *, uint8_t);
+typedef void (*put_priority_t)(void *, struct link_device *, long, uint8_t);
 
 /** Generic transmission transport header
  */
@@ -101,6 +102,7 @@ struct transport_tx {
   overrun_t overrun;                              ///< overrun
   count_bytes_t count_bytes;                      ///< count bytes to send
   void *impl;                                     ///< pointer to parent implementation
+  put_priority_t put_priority;                    ///< set a message priority
 };
 
 #ifdef __cplusplus

--- a/tools/generator/C/include_v2.0/pprzlink_transport.h
+++ b/tools/generator/C/include_v2.0/pprzlink_transport.h
@@ -89,6 +89,7 @@ typedef void (*start_message_t)(struct pprzlink_msg *, long, uint8_t);
 typedef void (*end_message_t)(struct pprzlink_msg *, long);
 typedef void (*overrun_t)(struct pprzlink_msg *);
 typedef void (*count_bytes_t)(struct pprzlink_msg *, uint8_t);
+typedef void (*put_priority_t)(void *, struct link_device *, long, uint8_t);
 
 /** Generic transmission transport header
  */
@@ -102,6 +103,7 @@ struct transport_tx {
   overrun_t overrun;                              ///< overrun
   count_bytes_t count_bytes;                      ///< count bytes to send
   void *impl;                                     ///< pointer to parent implementation
+  put_priority_t put_priority;                    ///< set a message priority
 };
 
 #ifdef __cplusplus

--- a/tools/generator/C/include_v2.0/pprzlink_transport.h
+++ b/tools/generator/C/include_v2.0/pprzlink_transport.h
@@ -89,7 +89,7 @@ typedef void (*start_message_t)(struct pprzlink_msg *, long, uint8_t);
 typedef void (*end_message_t)(struct pprzlink_msg *, long);
 typedef void (*overrun_t)(struct pprzlink_msg *);
 typedef void (*count_bytes_t)(struct pprzlink_msg *, uint8_t);
-typedef void (*put_priority_t)(void *, struct link_device *, long, uint8_t);
+typedef void (*put_priority_t)(struct pprzlink_msg *, long, uint8_t);
 
 /** Generic transmission transport header
  */

--- a/tools/generator/gen_messages_v1_0_c.py
+++ b/tools/generator/gen_messages_v1_0_c.py
@@ -69,6 +69,7 @@ static inline void pprz_msg_send_${msg_name}(struct transport_tx *trans, struct 
   if (trans->check_available_space(trans->impl, dev, _FD_ADDR, trans->size_of(trans->impl, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */))) {
     trans->count_bytes(trans->impl, dev, trans->size_of(trans->impl, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */));
     trans->start_message(trans->impl, dev, _FD, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */);
+    trans->put_priority(trans->impl, dev, _FD, DL_TYPE_UINT8, ${msg_priority} /* msg priority */);
     trans->put_bytes(trans->impl, dev, _FD, DL_TYPE_UINT8, DL_FORMAT_SCALAR, &ac_id, 1);
     trans->put_named_byte(trans->impl, dev, _FD, DL_TYPE_UINT8, DL_FORMAT_SCALAR, DL_${msg_name}, "${msg_name}");
     ${{fields:${array_byte}trans->put_bytes(trans->impl, dev, _FD, DL_TYPE_${type_upper}, ${dl_format}, (void *) _${field_name}, ${length});

--- a/tools/generator/gen_messages_v1_0_c.py
+++ b/tools/generator/gen_messages_v1_0_c.py
@@ -69,7 +69,7 @@ static inline void pprz_msg_send_${msg_name}(struct transport_tx *trans, struct 
   if (trans->check_available_space(trans->impl, dev, _FD_ADDR, trans->size_of(trans->impl, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */))) {
     trans->count_bytes(trans->impl, dev, trans->size_of(trans->impl, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */));
     trans->start_message(trans->impl, dev, _FD, 0${{fields:${array_extra_length}+${length}}} +2 /* msg header overhead */);
-    trans->put_priority(trans->impl, dev, _FD, DL_TYPE_UINT8, ${msg_priority} /* msg priority */);
+    trans->put_priority(trans->impl, dev, _FD, ${msg_priority} /* msg priority */);
     trans->put_bytes(trans->impl, dev, _FD, DL_TYPE_UINT8, DL_FORMAT_SCALAR, &ac_id, 1);
     trans->put_named_byte(trans->impl, dev, _FD, DL_TYPE_UINT8, DL_FORMAT_SCALAR, DL_${msg_name}, "${msg_name}");
     ${{fields:${array_byte}trans->put_bytes(trans->impl, dev, _FD, DL_TYPE_${type_upper}, ${dl_format}, (void *) _${field_name}, ${length});

--- a/tools/generator/gen_messages_v2_0_c.py
+++ b/tools/generator/gen_messages_v2_0_c.py
@@ -134,6 +134,7 @@ static inline void pprzlink_msg_v2_send_${msg_name}(struct pprzlink_msg * msg${{
   if (msg->trans->check_available_space(msg, _FD_ADDR, size)) {
     msg->trans->count_bytes(msg, size);
     msg->trans->start_message(msg, _FD, /* msg header overhead */4${{fields:${array_extra_length}+${length}}});
+    msg->trans->put_priority(trans->impl, dev, _FD, DL_TYPE_UINT8, ${msg_priority} /* msg priority */);
     msg->trans->put_bytes(msg, _FD, DL_TYPE_UINT8, DL_FORMAT_SCALAR, &(msg->sender_id), 1);
     msg->trans->put_named_byte(msg, _FD, DL_TYPE_UINT8, DL_FORMAT_SCALAR, msg->receiver_id, NULL);
     uint8_t comp_class = (msg->component_id & 0x0F) << 4 | (${class_id} & 0x0F);

--- a/tools/generator/gen_messages_v2_0_c.py
+++ b/tools/generator/gen_messages_v2_0_c.py
@@ -196,7 +196,7 @@ ${{fields:${read_array_byte}#define DL_${msg_name}_${field_name}(_payload) pprzl
 
 #endif // _VAR_MESSAGES_${class_name}_${msg_name}_H_
 
-''', {'msg_name' : m.msg_name, 'description' : m.description ,'class_id' : xml.class_id, 'class_name' : xml.class_name, 'id' : m.id, 'fields' : m.fields, 'message' : xml.message})
+''', {'msg_name' : m.msg_name, 'description' : m.description ,'class_id' : xml.class_id, 'class_name' : xml.class_name, 'id' : m.id, 'fields' : m.fields, 'message' : xml.message, 'msg_priority': m.msg_priority})
 
 
 def generate(output, xml):

--- a/tools/generator/gen_messages_v2_0_c.py
+++ b/tools/generator/gen_messages_v2_0_c.py
@@ -134,7 +134,7 @@ static inline void pprzlink_msg_v2_send_${msg_name}(struct pprzlink_msg * msg${{
   if (msg->trans->check_available_space(msg, _FD_ADDR, size)) {
     msg->trans->count_bytes(msg, size);
     msg->trans->start_message(msg, _FD, /* msg header overhead */4${{fields:${array_extra_length}+${length}}});
-    msg->trans->put_priority(trans->impl, dev, _FD, DL_TYPE_UINT8, ${msg_priority} /* msg priority */);
+    msg->trans->put_priority(msg, _FD, ${msg_priority} /* msg priority */);
     msg->trans->put_bytes(msg, _FD, DL_TYPE_UINT8, DL_FORMAT_SCALAR, &(msg->sender_id), 1);
     msg->trans->put_named_byte(msg, _FD, DL_TYPE_UINT8, DL_FORMAT_SCALAR, msg->receiver_id, NULL);
     uint8_t comp_class = (msg->component_id & 0x0F) << 4 | (${class_id} & 0x0F);

--- a/tools/generator/pprz_parse.py
+++ b/tools/generator/pprz_parse.py
@@ -79,7 +79,6 @@ class PPRZMsg(object):
     def __init__(self, name, id, linenumber, description='',  priority=1):
         self.msg_name = name
         self.linenumber = linenumber
-        print(priority)
         self.msg_priority = priority
         self.id = int(id)
         self.description = description
@@ -134,7 +133,7 @@ class PPRZXML(object):
                 check_attrs(attrs, ['name', 'id'], 'message')
                 if self.current_class == self.class_name:
                     priority = attrs['priority'] if 'priority' in attrs else 1
-                    self.message.append(PPRZMsg(attrs['name'], attrs['id'], p.CurrentLineNumber, priority=priority))
+                    self.message.append(PPRZMsg(attrs['name'], attrs['id'], p.CurrentLineNumber, priority=int(priority)))
             elif in_element == "protocol.msg_class.message.field":
                 check_attrs(attrs, ['name', 'type'], 'field')
                 if self.current_class == self.class_name:

--- a/tools/generator/pprz_parse.py
+++ b/tools/generator/pprz_parse.py
@@ -76,9 +76,10 @@ class PPRZField(object):
 
 
 class PPRZMsg(object):
-    def __init__(self, name, id, linenumber, description=''):
+    def __init__(self, name, id, linenumber, description='',  priority=1):
         self.msg_name = name
         self.linenumber = linenumber
+        self.msg_priority = priority
         self.id = int(id)
         self.description = description
         self.fields = []
@@ -131,6 +132,7 @@ class PPRZXML(object):
             elif in_element == "protocol.msg_class.message":
                 check_attrs(attrs, ['name', 'id'], 'message')
                 if self.current_class == self.class_name:
+                    priority = attrs['priority'] if 'priority' in attrs else 1
                     self.message.append(PPRZMsg(attrs['name'], attrs['id'], p.CurrentLineNumber))
             elif in_element == "protocol.msg_class.message.field":
                 check_attrs(attrs, ['name', 'type'], 'field')

--- a/tools/generator/pprz_parse.py
+++ b/tools/generator/pprz_parse.py
@@ -79,6 +79,7 @@ class PPRZMsg(object):
     def __init__(self, name, id, linenumber, description='',  priority=1):
         self.msg_name = name
         self.linenumber = linenumber
+        print(priority)
         self.msg_priority = priority
         self.id = int(id)
         self.description = description
@@ -133,7 +134,7 @@ class PPRZXML(object):
                 check_attrs(attrs, ['name', 'id'], 'message')
                 if self.current_class == self.class_name:
                     priority = attrs['priority'] if 'priority' in attrs else 1
-                    self.message.append(PPRZMsg(attrs['name'], attrs['id'], p.CurrentLineNumber))
+                    self.message.append(PPRZMsg(attrs['name'], attrs['id'], p.CurrentLineNumber, priority=priority))
             elif in_element == "protocol.msg_class.message.field":
                 check_attrs(attrs, ['name', 'type'], 'field')
                 if self.current_class == self.class_name:

--- a/tools/generator/pprz_schema.xsd
+++ b/tools/generator/pprz_schema.xsd
@@ -19,6 +19,7 @@
 <xs:attribute name="link" type="xs:string"/> <!-- message -->
 <xs:attribute name="format" type="xs:string"/> <!-- field -->
 <xs:attribute name="unit" type="xs:string"/> <!-- field -->
+<xs:attribute name="priority" type="xs:byte"/> <!-- message -->
 <xs:attribute name="alt_unit" type="xs:string"/> <!-- field -->
 <xs:attribute name="alt_unit_coef" type="xs:string"/> <!-- field (FIXME: should be decimal AND scientific notation, allow all strings as workaround for now -->
 <xs:attribute name="values" type="xs:string"/> <!-- field -->

--- a/tools/generator/pprz_schema.xsd
+++ b/tools/generator/pprz_schema.xsd
@@ -68,6 +68,7 @@
         <xs:attribute ref="name" use="required"/>
         <xs:attribute ref="id" use="required"/>
         <xs:attribute ref="link"/>
+        <xs:attribute ref="priority"/>
     </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
The attribute can be used for QoS if the transport layer implements so.

Default priority is 1, higher number has higher priority.

I added dummy `put_priority()` functions in `pprz_transport.c` for now.

I did some tests with priority queues, and it works as expected.
