### PR TITLE
Export pprz messages into OpenDDS format

### DIFF
--- a/tools/generator/gen_messages.py
+++ b/tools/generator/gen_messages.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     parser = ArgumentParser(description="This tool generate implementations from PPRZLink message definitions")
     parser.add_argument("-o", "--output", default="stdout", help="output file or stream [default: %(default)s]")
     parser.add_argument("--lang", dest="language", choices=supportedLanguages, default=DEFAULT_LANGUAGE, help="language of generated code [default: %(default)s]")
-    parser.add_argument("--protocol", choices=[pprz_parse.PROTOCOL_1_0,pprz_parse.PROTOCOL_2_0], default=DEFAULT_PROTOCOL, help="PPRZLink protocol version. [default: %(default)s]")
+    parser.add_argument("--protocol", choices=[pprz_parse.PROTOCOL_1_0,pprz_parse.PROTOCOL_2_0, pprz_parse.PROTOCOL_OPENDDS], default=DEFAULT_PROTOCOL, help="PPRZLink protocol version. [default: %(default)s]")
     parser.add_argument("--messages", choices=[pprz_parse.MESSAGES_1_0], default=DEFAULT_MESSAGES, help="PPRZLink message definitino version. [default: %(default)s]")
     parser.add_argument("--no-validate", action="store_false", dest="validate", default=DEFAULT_VALIDATE, help="Do not perform XML validation. Can speed up code generation if XML files are known to be correct.")
     parser.add_argument("--only-validate", action="store_true", dest="only_validate", help="Only validate messages without generation.")

--- a/tools/generator/gen_messages_opendds_c.py
+++ b/tools/generator/gen_messages_opendds_c.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+'''
+parse a PPRZLink protocol XML file and generate a OpenDDS compatible
+IDL file. See http://opendds.org/ for details. 
+
+Copyright (C) 2017 Michal Podhradsky <mpodhradsky@galois.com>
+For the Paparazzi UAV and PPRZLINK projects
+'''
+import re
+import sys, os
+import gen_messages, pprz_template, pprz_parse
+
+t = pprz_template.PPRZTemplate()
+
+def generate_messages_h(directory, name, xml):
+    print(xml)
+    '''generate messages header'''
+    if name == 'stdout':
+        f = sys.stdout
+    else:
+        f = open(os.path.join(directory, name), mode='w')
+    t.write(f,'''
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+  typedef sequence<unsigned short> unsigned_short_array; // uint8 ot uint16[]
+  typedef sequence<short> short_array; // int8 or int16[]
+  typedef sequence<unsigned long> unsigned_long_array; // uint32[]
+  typedef sequence<long> long_array; // int32[]
+  typedef sequence<float> float_array; // float[]
+  typedef sequence<double> double_array; // double[]
+
+module ${class_name} {
+${{message:
+#pragma DCPS_DATA_TYPE "${class_name}::${msg_name}"
+#pragma DCPS_DATA_TYPE "${class_name}::${msg_name} msg_id"
+
+struct ${msg_name} {
+    short msg_id;
+${{fields:    ${opendds_type} field_${attrib_macro}}}
+    };
+}}
+
+};
+''', xml)
+    if name != 'stdout':
+        f.close()
+
+def eval_int(expr):
+    import ast
+    return int(eval(compile(ast.parse(expr, mode='eval'), '<string>', 'eval')))
+
+def generate(output, xml):
+    '''generate complete PPRZLink C implemenation from a XML messages file'''
+
+    directory, name = os.path.split(output)
+
+
+    print("Generating C implementation in %s" % output)
+    if directory != '':
+        pprz_parse.mkdir_p(directory)
+    
+    # fix the class name to conform with standards
+    xml.class_name = xml.class_name.title() 
+
+    # add some extra field attributes for convenience with arrays
+    for m in xml.message:
+        m.msg_name = m.msg_name.title()
+        m.msg_name = re.sub('[_]', '', m.msg_name) 
+        offset = 2 # 2 bytes initial offset (sender id, message id)
+        for f in m.fields:
+            if f.type == 'uint8_t' or f.type == 'uint16_t' or f.type == 'char':
+                f.opendds_type = 'unsigned short'
+            elif f.type == 'int8_t' or f.type == 'int16_t':
+                f.opendds_type = 'short'
+            elif f.type == 'uint32_t':
+                f.opendds_type = 'unsigned long'
+            elif f.type == 'int32_t':
+                f.opendds_type = 'long'
+            elif f.type == 'float':
+                f.opendds_type = 'float'
+            elif f.type == 'double':
+                f.opendds_type = 'double'
+            else:
+                f.opendds_type = 'void'
+            
+            if not type(f.array_type) == type(None):
+                # it is an array - wrap as a stream
+                f.opendds_type = re.sub('[ ]', '_', f.opendds_type) + '_array'
+
+            f.attrib_macro = '%s;\n' % f.field_name
+
+    generate_messages_h(directory, name, xml)

--- a/tools/generator/gen_messages_v1_0_c.py
+++ b/tools/generator/gen_messages_v1_0_c.py
@@ -10,22 +10,10 @@ based on:
     Released under GNU GPL version 3 or later
 '''
 
-import sys, os
-import gen_messages, pprz_template, pprz_parse
-
-t = pprz_template.PPRZTemplate()
-
-def generate_messages_h(directory, name, xml):
-    print(xml)
-    '''generate messages header'''
-    if name == 'stdout':
-        f = sys.stdout
-    else:
-        f = open(os.path.join(directory, name), mode='w')
-    t.write(f,'''
+'''
 /** @file
- *	@brief PPRZLink messages header built from ${filename}
- *	@see http://paparazziuav.org
+ *    @brief PPRZLink messages header built from ${filename}
+ *    @see http://paparazziuav.org
  */
 #ifndef _VAR_MESSAGES_${class_name}_H_
 #define _VAR_MESSAGES_${class_name}_H_
@@ -93,6 +81,47 @@ ${{message:${{fields:${read_array_byte}#define DL_${msg_name}_${field_name}(_pay
 #endif // __cplusplus
 
 #endif // _VAR_MESSAGES_${class_name}_H_
+'''
+import re
+import sys, os
+import gen_messages, pprz_template, pprz_parse
+
+t = pprz_template.PPRZTemplate()
+
+def generate_messages_h(directory, name, xml):
+    print(xml)
+    '''generate messages header'''
+    if name == 'stdout':
+        f = sys.stdout
+    else:
+        f = open(os.path.join(directory, name), mode='w')
+    t.write(f,'''
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+  typedef sequence<unsigned short> unsigned_short_array; // uint8 ot uint16[]
+  typedef sequence<short> short_array; // int8 or int16[]
+  typedef sequence<unsigned long> unsigned_long_array; // uint32[]
+  typedef sequence<long> long_array; // int32[]
+  typedef sequence<float> float_array; // float[]
+  typedef sequence<double> double_array; // double[]
+
+module ${class_name} {
+${{message:
+#pragma DCPS_DATA_TYPE "${class_name}::${msg_name}"
+#pragma DCPS_DATA_TYPE "${class_name}::${msg_name} msg_id"
+
+struct ${msg_name} {
+    short msg_id;
+${{fields:    ${opendds_type} field_${attrib_macro}}}
+    };
+}}
+
+};
 ''', xml)
     if name != 'stdout':
         f.close()
@@ -126,11 +155,37 @@ def generate(output, xml):
     print("Generating C implementation in %s" % output)
     if directory != '':
         pprz_parse.mkdir_p(directory)
+    
+    # fix the class name to conform with standards
+    xml.class_name = xml.class_name.title() 
 
     # add some extra field attributes for convenience with arrays
     for m in xml.message:
+        m.msg_name = m.msg_name.title()
+        m.msg_name = re.sub('[_]', '', m.msg_name) 
         offset = 2 # 2 bytes initial offset (sender id, message id)
         for f in m.fields:
+            if f.type == 'uint8_t' or f.type == 'uint16_t' or f.type == 'char':
+                f.opendds_type = 'unsigned short'
+            elif f.type == 'int8_t' or f.type == 'int16_t':
+                f.opendds_type = 'short'
+            elif f.type == 'uint32_t':
+                f.opendds_type = 'unsigned long'
+            elif f.type == 'int32_t':
+                f.opendds_type = 'long'
+            elif f.type == 'float':
+                f.opendds_type = 'float'
+            elif f.type == 'double':
+                f.opendds_type = 'double'
+            else:
+                f.opendds_type = 'void'
+            
+            if not type(f.array_type) == type(None):
+                # it is an array - wrap as a stream
+                f.opendds_type = re.sub('[ ]', '_', f.opendds_type) + '_array'
+
+            f.attrib_macro = '%s;\n' % f.field_name
+            '''
             if f.array_type == 'VariableArray':
                 f.attrib_macro = 'nb_%s, %s' % (f.field_name, f.field_name)
                 f.attrib_fun = 'uint8_t nb_%s, %s *_%s' % (f.field_name, f.type, f.field_name)
@@ -161,13 +216,14 @@ def generate(output, xml):
             else:
                 f.offset = offset
                 offset += int(f.length)
-                f.attrib_macro = '%s' % f.field_name
+                f.attrib_macro = '%s;\n' % f.field_name
                 f.attrib_fun = '%s *_%s' % (f.type, f.field_name)
                 f.attrib_fun_unused = '%s *_%s __attribute__((unused))' % (f.type, f.field_name)
                 f.array_byte = ''
                 f.read_type = f.type
                 f.read_array_byte = ''
                 f.dl_format = 'DL_FORMAT_SCALAR'
+            '''
 
     generate_messages_h(directory, name, xml)
     copy_fixed_headers(directory, xml.protocol_version)

--- a/tools/generator/gen_messages_v1_0_c.py
+++ b/tools/generator/gen_messages_v1_0_c.py
@@ -10,7 +10,19 @@ based on:
     Released under GNU GPL version 3 or later
 '''
 
-'''
+import sys, os
+import gen_messages, pprz_template, pprz_parse
+
+t = pprz_template.PPRZTemplate()
+
+def generate_messages_h(directory, name, xml):
+    print(xml)
+    '''generate messages header'''
+    if name == 'stdout':
+        f = sys.stdout
+    else:
+        f = open(os.path.join(directory, name), mode='w')
+    t.write(f,'''
 /** @file
  *    @brief PPRZLink messages header built from ${filename}
  *    @see http://paparazziuav.org
@@ -81,47 +93,6 @@ ${{message:${{fields:${read_array_byte}#define DL_${msg_name}_${field_name}(_pay
 #endif // __cplusplus
 
 #endif // _VAR_MESSAGES_${class_name}_H_
-'''
-import re
-import sys, os
-import gen_messages, pprz_template, pprz_parse
-
-t = pprz_template.PPRZTemplate()
-
-def generate_messages_h(directory, name, xml):
-    print(xml)
-    '''generate messages header'''
-    if name == 'stdout':
-        f = sys.stdout
-    else:
-        f = open(os.path.join(directory, name), mode='w')
-    t.write(f,'''
-/*
- *
- *
- * Distributed under the OpenDDS License.
- * See: http://www.opendds.org/license.html
- */
-
-  typedef sequence<unsigned short> unsigned_short_array; // uint8 ot uint16[]
-  typedef sequence<short> short_array; // int8 or int16[]
-  typedef sequence<unsigned long> unsigned_long_array; // uint32[]
-  typedef sequence<long> long_array; // int32[]
-  typedef sequence<float> float_array; // float[]
-  typedef sequence<double> double_array; // double[]
-
-module ${class_name} {
-${{message:
-#pragma DCPS_DATA_TYPE "${class_name}::${msg_name}"
-#pragma DCPS_DATA_TYPE "${class_name}::${msg_name} msg_id"
-
-struct ${msg_name} {
-    short msg_id;
-${{fields:    ${opendds_type} field_${attrib_macro}}}
-    };
-}}
-
-};
 ''', xml)
     if name != 'stdout':
         f.close()
@@ -155,37 +126,11 @@ def generate(output, xml):
     print("Generating C implementation in %s" % output)
     if directory != '':
         pprz_parse.mkdir_p(directory)
-    
-    # fix the class name to conform with standards
-    xml.class_name = xml.class_name.title() 
 
     # add some extra field attributes for convenience with arrays
     for m in xml.message:
-        m.msg_name = m.msg_name.title()
-        m.msg_name = re.sub('[_]', '', m.msg_name) 
         offset = 2 # 2 bytes initial offset (sender id, message id)
         for f in m.fields:
-            if f.type == 'uint8_t' or f.type == 'uint16_t' or f.type == 'char':
-                f.opendds_type = 'unsigned short'
-            elif f.type == 'int8_t' or f.type == 'int16_t':
-                f.opendds_type = 'short'
-            elif f.type == 'uint32_t':
-                f.opendds_type = 'unsigned long'
-            elif f.type == 'int32_t':
-                f.opendds_type = 'long'
-            elif f.type == 'float':
-                f.opendds_type = 'float'
-            elif f.type == 'double':
-                f.opendds_type = 'double'
-            else:
-                f.opendds_type = 'void'
-            
-            if not type(f.array_type) == type(None):
-                # it is an array - wrap as a stream
-                f.opendds_type = re.sub('[ ]', '_', f.opendds_type) + '_array'
-
-            f.attrib_macro = '%s;\n' % f.field_name
-            '''
             if f.array_type == 'VariableArray':
                 f.attrib_macro = 'nb_%s, %s' % (f.field_name, f.field_name)
                 f.attrib_fun = 'uint8_t nb_%s, %s *_%s' % (f.field_name, f.type, f.field_name)
@@ -216,14 +161,13 @@ def generate(output, xml):
             else:
                 f.offset = offset
                 offset += int(f.length)
-                f.attrib_macro = '%s;\n' % f.field_name
+                f.attrib_macro = '%s' % f.field_name
                 f.attrib_fun = '%s *_%s' % (f.type, f.field_name)
                 f.attrib_fun_unused = '%s *_%s __attribute__((unused))' % (f.type, f.field_name)
                 f.array_byte = ''
                 f.read_type = f.type
                 f.read_array_byte = ''
                 f.dl_format = 'DL_FORMAT_SCALAR'
-            '''
 
     generate_messages_h(directory, name, xml)
     copy_fixed_headers(directory, xml.protocol_version)

--- a/tools/generator/pprz_parse.py
+++ b/tools/generator/pprz_parse.py
@@ -14,6 +14,7 @@ import xml.parsers.expat, os, errno, time, sys, operator, struct
 
 PROTOCOL_1_0 = "1.0"
 PROTOCOL_2_0 = "2.0"
+PROTOCOL_OPENDDS = "DDS"
 MESSAGES_1_0 = "1.0"
 
 class PPRZParseError(Exception):
@@ -101,9 +102,13 @@ class PPRZXML(object):
             self.protocol_version_major = 2
             self.protocol_version_minor = 0
             self.generator_module = "gen_messages_v2_0"
+        elif protocol_version == PROTOCOL_OPENDDS:
+            self.protocol_version_major = 0
+            self.protocol_version_minor = 0
+            self.generator_module = "gen_messages_opendds"
         else:
             print("Unknown wire protocol version")
-            print("Available versions are: %s" % (PROTOCOL_1_0))
+            print("Available versions are: %s, %s and %s" % (PROTOCOL_1_0, PROTOCOL_2_0, PROTOCOL_OPENDDS))
             raise PPRZParseError('Unknown PPRZLink protocol version %s' % protocol_version)
 
         in_element_list = []


### PR DESCRIPTION
OpenDDS is an open source implementation of Publisher-Subscriber communication service (more info here http://opendds.org/).

This PR adds an option to generate OpenDDS compatible IDL format from messages.xml.

More information and an example of OpenDDS<-->Pprzlink communication will follow, but I am seeking some early feedback on the Python implementation. Plus this works as is.