### PR TITLE
Refactored secure link

### DIFF
--- a/lib/common/C/spprz_utils.c
+++ b/lib/common/C/spprz_utils.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017 Michal Podhradsky <mpodhradsky@galois.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file pprzlink/spprz_utils.c
+ *
+ * Default Secure link implementation
+ * for demonstration purposes
+ *
+ */
+#include "pprzlink/spprz_utils.h"
+
+/**
+ * Trivial implementation of the processing function
+ * Shall be replaced by user implementation!
+ *
+ * This function only copies trans->trans_rx.payload into provided buf
+ */
+bool WEAK spprz_process_incoming_packet(struct spprz_transport *trans, uint8_t *buf)
+{
+  for (uint8_t i = 0; i < trans->trans_rx.payload_len; i++) {
+    buf[i] = trans->trans_rx.payload[i];
+  }
+  return true;
+}
+
+/**
+ * Trivial implementation of the processing function
+ * Shall be replaced by user implementation!
+ *
+ * This function is only a pass-through.
+ */
+bool WEAK spprz_process_outgoing_packet(struct spprz_transport *trans __attribute__((unused)))
+{
+  return true ;
+}

--- a/lib/common/C/spprz_utils.c
+++ b/lib/common/C/spprz_utils.c
@@ -27,6 +27,7 @@
  */
 #include "pprzlink/spprz_utils.h"
 
+
 /**
  * Trivial implementation of the processing function
  * Shall be replaced by user implementation!
@@ -49,5 +50,5 @@ bool WEAK spprz_process_incoming_packet(struct spprz_transport *trans, uint8_t *
  */
 bool WEAK spprz_process_outgoing_packet(struct spprz_transport *trans __attribute__((unused)))
 {
-  return true ;
+  return true;
 }

--- a/lib/common/C/spprz_utils.h
+++ b/lib/common/C/spprz_utils.h
@@ -24,7 +24,7 @@
  * Secure link utilities
  *
  */
-
+#pragma once
 #ifndef SPPRZ_UTILS_H
 #define SPRRZ_UTILS_H
 
@@ -32,31 +32,12 @@
 extern "C" {
 #endif
 
-#include "std.h";
+#include "std.h"
+#include "pprzlink/spprz_transport.h"
 
-// mutexes
 #define PPRZ_STX_SECURE 0xAA
 #define PPRZ_MSG_LEN_IDX 1
 
-#ifndef PPRZ_MUTEX
-#define PPRZ_MUTEX(_mtx)
-#endif
-
-#ifndef PPRZ_MUTEX_DECL
-#define PPRZ_MUTEX_DECL(_mtx)
-#endif
-
-#ifndef PPRZ_MUTEX_INIT
-#define PPRZ_MUTEX_INIT(_mtx) {}
-#endif
-
-#ifndef PPRZ_MUTEX_LOCK
-#define PPRZ_MUTEX_LOCK(_mtx) {}
-#endif
-
-#ifndef PPRZ_MUTEX_UNLOCK
-#define PPRZ_MUTEX_UNLOCK(_mtx) {}
-#endif
 
 /* Function shall be provided implementation */
 
@@ -82,7 +63,7 @@ extern "C" {
  *
  * Note: in case the function returns false, it is expected to log an error
  */
-extern bool spprz_process_incoming_packet(struct spprz_transport *trans, uint8_t *buf);
+bool spprz_process_incoming_packet(struct spprz_transport *trans, uint8_t *buf);
 
 /**
  * Process outgoing packet
@@ -109,36 +90,7 @@ extern bool spprz_process_incoming_packet(struct spprz_transport *trans, uint8_t
  *
  * Note: in case the function returns false, it is expected to log an error
  */
-extern bool spprz_process_outgoing_packet(struct spprz_transport *trans);
-
-
-
-
-
-/**
- * Trivial implementation of the processing function
- * Shall be replaced by user implementation!
- *
- * This function only copies trans->trans_rx.payload into provided buf
- */
-bool WEAK spprz_process_incoming_packet(struct spprz_transport *trans, uint8_t *buf)
-{
-  for (uint8_t i = 0; i < trans->trans_rx.payload_len; i++) {
-    buf[i] = trans->trans_rx.payload[i];
-  }
-  return true;
-}
-
-/**
- * Trivial implementation of the processing function
- * Shall be replaced by user implementation!
- *
- * This function is only a pass-through.
- */
-bool WEAK spprz_process_outgoing_packet(struct spprz_transport *trans)
-{
-  return true;
-}
+bool spprz_process_outgoing_packet(struct spprz_transport *trans);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lib/common/C/spprz_utils.h
+++ b/lib/common/C/spprz_utils.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2017 Michal Podhradsky <mpodhradsky@galois.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file pprzlink/spprz_utils.h
+ *
+ * Secure link utilities
+ *
+ */
+
+#ifndef SPPRZ_UTILS_H
+#define SPRRZ_UTILS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "std.h";
+
+// mutexes
+#define PPRZ_STX_SECURE 0xAA
+#define PPRZ_MSG_LEN_IDX 1
+
+#ifndef PPRZ_MUTEX
+#define PPRZ_MUTEX(_mtx)
+#endif
+
+#ifndef PPRZ_MUTEX_DECL
+#define PPRZ_MUTEX_DECL(_mtx)
+#endif
+
+#ifndef PPRZ_MUTEX_INIT
+#define PPRZ_MUTEX_INIT(_mtx) {}
+#endif
+
+#ifndef PPRZ_MUTEX_LOCK
+#define PPRZ_MUTEX_LOCK(_mtx) {}
+#endif
+
+#ifndef PPRZ_MUTEX_UNLOCK
+#define PPRZ_MUTEX_UNLOCK(_mtx) {}
+#endif
+
+/* Function shall be provided implementation */
+
+/**
+ * Process incoming packet.
+ *
+ * The packet is stripped of STX, LEN, and Checksum
+ * The packet status (encrypted/plaintext) based on STX type is encoded in
+ * trans->packet_encrypted
+ *
+ * trans->trans_rx.payload  - contains the payload data
+ * trans->trans_rx.payload_len - payload data length
+ *
+ * buf - a buffer containing processed payload. In trivial case, it is a copy of
+ * trans->trans_rx.payload
+ *
+ * The format is expected to comply with Pprzlink protocol of given version (1.0/2.0) and is
+ * up to the implementation to ensure.
+ *
+ * Returns:
+ * true - if the packet should be received
+ * false - if the packet should be discarded
+ *
+ * Note: in case the function returns false, it is expected to log an error
+ */
+extern bool spprz_process_incoming_packet(struct spprz_transport *trans, uint8_t *buf);
+
+/**
+ * Process outgoing packet
+ *
+ * The received trans->tx_msg has the following format:
+ * trans->tx_msg[0] = PPRZ_STX
+ * trans->tx_msg[1] = msg_len (including checksum and unsecured protocol overhead)
+ * trans->tx_msg[2+] = payload
+ *
+ * trans->tx_msg_idx doesn't include checksum (so msg_len = tx_msg_idx + 2)
+ *
+ * The returned trans->tx_msg buffer shall have the following format:
+ * trans->tx_msg[0] = PPRZ_STX or PPRZ_STX_SECURE
+ * trans->tx_msg[1] = msg_len (including any additional cryptographic overhead and checksum)
+ * trans->tx_msg[2+] = additional data and payload
+ *
+ * trans->tx_msg_idx does not include checksum! (so msg_len = tx_msg_idx + 2)
+ *
+ * Checksum is calculated before sending in end_message() function
+ *
+ * Returns:
+ * true - if the packet should be sent
+ * false - if the packet should be discarded
+ *
+ * Note: in case the function returns false, it is expected to log an error
+ */
+extern bool spprz_process_outgoing_packet(struct spprz_transport *trans);
+
+
+
+
+
+/**
+ * Trivial implementation of the processing function
+ * Shall be replaced by user implementation!
+ *
+ * This function only copies trans->trans_rx.payload into provided buf
+ */
+bool WEAK spprz_process_incoming_packet(struct spprz_transport *trans, uint8_t *buf)
+{
+  for (uint8_t i = 0; i < trans->trans_rx.payload_len; i++) {
+    buf[i] = trans->trans_rx.payload[i];
+  }
+  return true;
+}
+
+/**
+ * Trivial implementation of the processing function
+ * Shall be replaced by user implementation!
+ *
+ * This function is only a pass-through.
+ */
+bool WEAK spprz_process_outgoing_packet(struct spprz_transport *trans)
+{
+  return true;
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* SPPRZ_UTILS_H */
+

--- a/lib/v1.0/C/Makefile
+++ b/lib/v1.0/C/Makefile
@@ -24,7 +24,7 @@ MAKE = make
 all:
 
 install:
-#	$(Q)cp ../../common/C/*.c $(MESSAGES_LIB)
+	$(Q)cp ../../common/C/*.c $(MESSAGES_LIB)
 	$(Q)cp ../../common/C/*.h $(MESSAGES_INCLUDE)
 	$(Q)cp ./*.h $(MESSAGES_INCLUDE)
 	$(Q)cp ./*.c $(MESSAGES_LIB)

--- a/lib/v1.0/C/spprz_transport.c
+++ b/lib/v1.0/C/spprz_transport.c
@@ -115,6 +115,10 @@ static void end_message(struct spprz_transport *trans, struct link_device *dev, 
     trans->ck_a_tx = trans->tx_msg[PPRZ_MSG_LEN_IDX];
     trans->ck_b_tx = trans->tx_msg[PPRZ_MSG_LEN_IDX];
 
+    // send first two bytes
+    dev->put_byte(dev->periph, fd, trans->tx_msg[0]);
+    dev->put_byte(dev->periph, fd, trans->tx_msg[1]);
+
     // we start counting checksum at byte 2
     for (uint8_t i=2; i<trans->tx_msg_idx; i++) {
       accumulate_checksum(trans, trans->tx_msg[i]);

--- a/lib/v1.0/C/spprz_transport.c
+++ b/lib/v1.0/C/spprz_transport.c
@@ -42,6 +42,7 @@
  */
 
 #include <inttypes.h>
+#include <string.h> // for memset()
 #include "pprzlink/spprz_transport.h"
 
 // PPRZ parsing state machine
@@ -148,7 +149,7 @@ static int check_available_space(struct spprz_transport *trans __attribute__((un
 }
 
 // Init pprz transport structure
-void pprz_transport_init(struct spprz_transport *t)
+void spprz_transport_init(struct spprz_transport *t)
 {
   t->status = UNINIT;
   t->trans_rx.msg_received = false;
@@ -231,7 +232,7 @@ void spprz_check_and_parse(struct link_device *dev, struct spprz_transport *tran
 {
   if (dev->char_available(dev->periph)) {
     while (dev->char_available(dev->periph) && !trans->trans_rx.msg_received) {
-      parse_pprz(trans, dev->get_byte(dev->periph));
+      parse_spprz(trans, dev->get_byte(dev->periph));
     }
     if (trans->trans_rx.msg_received) {
       if (spprz_process_incoming_packet(trans, buf)) {

--- a/lib/v1.0/C/spprz_transport.c
+++ b/lib/v1.0/C/spprz_transport.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2006  Pascal Brisset, Antoine Drouin
+ * Copyright (C) 2014-2015  Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Copyright (C) 2017 Michal Podhradsky <mpodhradsky@galois.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file pprzlink/spprz_transport.c
+ *
+ * Building and parsing secure Paparazzi frames.
+ * Provides only basic hooks, the majority of work (encryption/decryption)
+ * is done in an external user-supplied file.
+ *
+ * Pprz frame:
+ *
+ * |STX|length|... payload=(length-4) bytes ...|Checksum A|Checksum B|
+ *
+ * where checksum is computed over length and payload:
+ * @code
+ * ck_A = ck_B = length
+ * for each byte b in payload
+ *     ck_A += b;
+ *     ck_b += ck_A;
+ * @endcode
+ */
+
+#include <inttypes.h>
+#include "pprzlink/spprz_transport.h"
+
+// PPRZ parsing state machine
+#define UNINIT      0
+#define GOT_STX     1
+#define GOT_LENGTH  2
+#define GOT_PAYLOAD 3
+#define GOT_CRC1    4
+
+
+static void accumulate_checksum(struct spprz_transport *trans, const uint8_t byte)
+{
+  trans->ck_a_tx += byte;
+  trans->ck_b_tx += trans->ck_a_tx;
+}
+
+static inline void insert_byte(struct spprz_transport *trans, const uint8_t byte) {
+  trans->tx_msg[trans->tx_msg_idx] = byte;
+  trans->tx_msg_idx++;
+}
+
+static void put_bytes(struct spprz_transport *trans,
+                      struct link_device *dev __attribute__((unused)),
+                      long fd __attribute__((unused)),
+                      enum TransportDataType type __attribute__((unused)),
+                      enum TransportDataFormat format __attribute__((unused)),
+                      const void *bytes, uint16_t len)
+{
+  const uint8_t *b = (const uint8_t *) bytes;
+  int i;
+  for (i = 0; i < len; i++) {
+    insert_byte(trans, b[i]);
+  }
+}
+
+static void put_named_byte(struct spprz_transport *trans,
+                           struct link_device *dev __attribute__((unused)),
+                           long fd __attribute__((unused)),
+                           enum TransportDataType type __attribute__((unused)),
+                           enum TransportDataFormat format __attribute__((unused)),
+                           uint8_t byte,
+                           const char *name __attribute__((unused)))
+{
+  insert_byte(trans, byte);
+}
+
+static uint8_t size_of(struct spprz_transport *trans __attribute__((unused)), uint8_t len)
+{
+  // message length: payload + protocol overhead (STX + len + ck_a + ck_b = 4)
+  return len + 4;
+}
+
+static void start_message(struct spprz_transport *trans,
+                          struct link_device *dev __attribute__((unused)),
+                          long fd __attribute__((unused)),
+                          uint8_t payload_len)
+{
+  PPRZ_MUTEX_LOCK(trans->spprz_mtx_tx); // lock mutex
+  memset(trans->tx_msg, 0, TRANSPORT_PAYLOAD_LEN);
+  trans->tx_msg_idx = 0;
+
+  insert_byte(trans, PPRZ_STX);
+  const uint8_t msg_len = size_of(trans, payload_len);
+  insert_byte(trans, msg_len);
+}
+
+static void end_message(struct spprz_transport *trans, struct link_device *dev, long fd)
+{
+  if (spprz_process_outgoing_packet(trans)) {
+    trans->ck_a_tx = trans->tx_msg[PPRZ_MSG_LEN_IDX];
+    trans->ck_b_tx = trans->tx_msg[PPRZ_MSG_LEN_IDX];
+
+    // we start counting checksum at byte 2
+    for (uint8_t i=2; i<trans->tx_msg_idx; i++) {
+      accumulate_checksum(trans, trans->tx_msg[i]);
+      dev->put_byte(dev->periph, fd, trans->tx_msg[i]);
+    }
+
+    // append checksum & send message
+    dev->put_byte(dev->periph, fd, trans->ck_a_tx);
+    dev->put_byte(dev->periph, fd, trans->ck_b_tx);
+    dev->send_message(dev->periph, fd);
+  }
+  PPRZ_MUTEX_UNLOCK(trans->spprz_mtx_tx); // unlock mutex
+}
+
+static void overrun(struct spprz_transport *trans __attribute__((unused)), struct link_device *dev)
+{
+  dev->nb_ovrn++;
+}
+
+static void count_bytes(struct spprz_transport *trans __attribute__((unused)),
+                        struct link_device *dev, uint8_t bytes)
+{
+  dev->nb_bytes += bytes;
+}
+
+static int check_available_space(struct spprz_transport *trans __attribute__((unused)),
+                                 struct link_device *dev,
+                                 long *fd, uint16_t bytes)
+{
+  // TODO: might not be necessary
+  return dev->check_free_space(dev->periph, fd, bytes);
+}
+
+// Init pprz transport structure
+void pprz_transport_init(struct spprz_transport *t)
+{
+  t->status = UNINIT;
+  t->trans_rx.msg_received = false;
+  t->trans_tx.size_of = (size_of_t) size_of;
+  t->trans_tx.check_available_space = (check_available_space_t) check_available_space;
+  t->trans_tx.put_bytes = (put_bytes_t) put_bytes;
+  t->trans_tx.put_named_byte = (put_named_byte_t) put_named_byte;
+  t->trans_tx.start_message = (start_message_t) start_message;
+  t->trans_tx.end_message = (end_message_t) end_message;
+  t->trans_tx.overrun = (overrun_t) overrun;
+  t->trans_tx.count_bytes = (count_bytes_t) count_bytes;
+  t->trans_tx.impl = (void *)(t);
+  PPRZ_MUTEX_INIT(t->spprz_mtx_tx); // init mutex, check if correct pointer
+}
+
+
+// Parsing function
+void parse_spprz(struct spprz_transport *t, uint8_t c)
+{
+  switch (t->status) {
+    case UNINIT:
+      switch (c) {
+        case PPRZ_STX:
+          t->status++;
+          t->packet_encrypted = false;
+          break;
+        case PPRZ_STX_SECURE:
+          t->status++;
+          t->packet_encrypted = true;
+          break;
+        default:
+          break;
+      }
+      break;
+    case GOT_STX:
+      if (t->trans_rx.msg_received) {
+        t->trans_rx.ovrn++;
+        goto error;
+      }
+      t->trans_rx.payload_len = c - 4; /* Counting STX, LENGTH and CRC1 and CRC2 */
+      t->ck_a_rx = t->ck_b_rx = c;
+      t->status++;
+      t->payload_idx = 0;
+      break;
+    case GOT_LENGTH:
+      t->trans_rx.payload[t->payload_idx] = c;
+      t->ck_a_rx += c; t->ck_b_rx += t->ck_a_rx;
+      t->payload_idx++;
+      if (t->payload_idx == t->trans_rx.payload_len) {
+        t->status++;
+      }
+      break;
+    case GOT_PAYLOAD:
+      if (c != t->ck_a_rx) {
+        goto error;
+      }
+      t->status++;
+      break;
+    case GOT_CRC1:
+      if (c != t->ck_b_rx) {
+        goto error;
+      }
+      t->trans_rx.msg_received = true;
+      goto restart;
+    default:
+      goto error;
+  }
+  return;
+error:
+  t->trans_rx.error++;
+restart:
+  t->status = UNINIT;
+  return;
+}
+
+
+/** Parsing a frame data and copy the payload to the datalink buffer */
+void spprz_check_and_parse(struct link_device *dev, struct spprz_transport *trans,
+                           uint8_t *buf, bool *msg_available)
+{
+  if (dev->char_available(dev->periph)) {
+    while (dev->char_available(dev->periph) && !trans->trans_rx.msg_received) {
+      parse_pprz(trans, dev->get_byte(dev->periph));
+    }
+    if (trans->trans_rx.msg_received) {
+      if (spprz_process_incoming_packet(trans, buf)) {
+        *msg_available = true;
+      }
+      trans->trans_rx.msg_received = false;
+    }
+  }
+}

--- a/lib/v1.0/C/spprz_transport.h
+++ b/lib/v1.0/C/spprz_transport.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2003  Pascal Brisset, Antoine Drouin
+ * Copyright (C) 2015  Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Copyright (C) 2017 Michal Podhradsky <mpodhradsky@galois.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file pprzlink/spprz_transport.h
+ *
+ * Building and parsing secure Paparazzi frames.
+ * Provides only basic hooks, the majority of work (encryption/decryption)
+ * is done in an external user-supplied file.
+ *
+ * Pprz frame:
+ *
+ * |STX|length|... payload=(length-4) bytes ...|Checksum A|Checksum B|
+ *
+ * where checksum is computed over length and payload:
+ * @code
+ * ck_A = ck_B = length
+ * for each byte b in payload
+ *     ck_A += b;
+ *     ck_b += ck_A;
+ * @endcode
+ */
+
+#ifndef SPPRZ_TRANSPORT_H
+#define SPPRZ_TRANSPORT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include "pprzlink/pprzlink_transport.h"
+#include "pprzlink/pprzlink_device.h"
+#include "pprzlink/spprz_utils.h"
+
+// Start byte
+#define PPRZ_STX        0x99
+
+/* PPRZ Transport
+ */
+struct spprz_transport {
+  // generic reception interface
+  struct transport_rx trans_rx;
+  // specific pprz transport_rx variables
+  uint8_t status;
+  uint8_t payload_idx;
+  uint8_t ck_a_rx, ck_b_rx;
+
+  // generic transmission interface
+  struct transport_tx trans_tx;
+  // specific pprz transport_tx variables
+  uint8_t ck_a_tx, ck_b_tx;
+  // buffered tx message
+  uint8_t tx_msg[TRANSPORT_PAYLOAD_LEN];
+  volatile uint8_t tx_msg_idx;
+  bool packet_encrypted;
+  PPRZ_MUTEX(spprz_mtx_tx); // mutex is a part of the transport
+};
+
+// Init function
+extern void spprz_transport_init(struct spprz_transport *t);
+
+// Checking new data and parsing
+extern void spprz_check_and_parse(struct link_device *dev, struct spprz_transport *trans, uint8_t *buf, bool *msg_available);
+
+// Parsing function, only needed for modules doing their own parsing
+// without using the pprz_check_and_parse function
+extern void parse_spprz(struct spprz_transport *t, uint8_t c);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* SPPRZ_TRANSPORT_H */
+

--- a/lib/v1.0/C/spprz_transport.h
+++ b/lib/v1.0/C/spprz_transport.h
@@ -52,7 +52,7 @@ extern "C" {
 #include <stdbool.h>
 #include "pprzlink/pprzlink_transport.h"
 #include "pprzlink/pprzlink_device.h"
-#include "pprzlink/spprz_utils.h"
+#include "pprz_mutex.h" // mutex definitions
 
 // Start byte
 #define PPRZ_STX        0x99
@@ -77,6 +77,9 @@ struct spprz_transport {
   bool packet_encrypted;
   PPRZ_MUTEX(spprz_mtx_tx); // mutex is a part of the transport
 };
+
+// include after defining the spprz_stransport struct
+#include "pprzlink/spprz_utils.h"
 
 // Init function
 extern void spprz_transport_init(struct spprz_transport *t);

--- a/lib/v1.0/C/spprz_transport.h
+++ b/lib/v1.0/C/spprz_transport.h
@@ -52,7 +52,6 @@ extern "C" {
 #include <stdbool.h>
 #include "pprzlink/pprzlink_transport.h"
 #include "pprzlink/pprzlink_device.h"
-#include "pprz_mutex.h" // mutex definitions
 
 // Start byte
 #define PPRZ_STX        0x99
@@ -66,16 +65,16 @@ struct spprz_transport {
   uint8_t status;
   uint8_t payload_idx;
   uint8_t ck_a_rx, ck_b_rx;
-
   // generic transmission interface
   struct transport_tx trans_tx;
   // specific pprz transport_tx variables
   uint8_t ck_a_tx, ck_b_tx;
+
+  // secure link specific:
   // buffered tx message
   uint8_t tx_msg[TRANSPORT_PAYLOAD_LEN];
   volatile uint8_t tx_msg_idx;
-  bool packet_encrypted;
-  PPRZ_MUTEX(spprz_mtx_tx); // mutex is a part of the transport
+  uint8_t packet_type;
 };
 
 // include after defining the spprz_stransport struct

--- a/lib/v2.0/C/Makefile
+++ b/lib/v2.0/C/Makefile
@@ -24,7 +24,7 @@ MAKE = make
 all:
 
 install:
-#	$(Q)cp ../../common/C/*.c $(MESSAGES_LIB)
+	$(Q)cp ../../common/C/*.c $(MESSAGES_LIB)
 	$(Q)cp ../../common/C/*.h $(MESSAGES_INCLUDE)
 	$(Q)cp ./*.h $(MESSAGES_INCLUDE)
 	$(Q)cp ./*.c $(MESSAGES_LIB)

--- a/lib/v2.0/C/pprz_transport.c
+++ b/lib/v2.0/C/pprz_transport.c
@@ -39,7 +39,7 @@
  */
 
 #include <inttypes.h>
-#include "pprzlink/pprz_transport.h"
+#include "pprzlink/spprz_transport.h"
 
 // PPRZ parsing state machine
 #define UNINIT      0

--- a/lib/v2.0/C/pprz_transport.c
+++ b/lib/v2.0/C/pprz_transport.c
@@ -39,7 +39,7 @@
  */
 
 #include <inttypes.h>
-#include "pprzlink/spprz_transport.h"
+#include "pprzlink/pprz_transport.h"
 
 // PPRZ parsing state machine
 #define UNINIT      0

--- a/lib/v2.0/C/spprz_transport.c
+++ b/lib/v2.0/C/spprz_transport.c
@@ -48,7 +48,7 @@
 #define GOT_PAYLOAD 3
 #define GOT_CRC1    4
 
-static struct pprz_transport * get_pprz_trans(struct pprzlink_msg *msg)
+static struct spprz_transport * get_pprz_trans(struct pprzlink_msg *msg)
 {
   return (struct spprz_transport *)(msg->trans->impl);
 }

--- a/lib/v2.0/C/spprz_transport.c
+++ b/lib/v2.0/C/spprz_transport.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2006  Pascal Brisset, Antoine Drouin
+ * Copyright (C) 2014-2015  Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Copyright (C) 2017 Michal Podhradsky <mpodhradsky@galois.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file pprzlink/spprz_transport.c
+ *
+ * Building and parsing secure Paparazzi frames.
+ * Provides only basic hooks, the majority of work (encryption/decryption)
+ * is done in an external user-supplied file.
+ *
+ * Pprz frame:
+ *
+ * |STX|length|... payload=(length-4) bytes ...|Checksum A|Checksum B|
+ *
+ * where checksum is computed over length and payload:
+ * @code
+ * ck_A = ck_B = length
+ * for each byte b in payload
+ *     ck_A += b;
+ *     ck_b += ck_A;
+ * @endcode
+ */
+
+#include <inttypes.h>
+#include <string.h> // for memset()
+#include "pprzlink/spprz_transport.h"
+
+// PPRZ parsing state machine
+#define UNINIT      0
+#define GOT_STX     1
+#define GOT_LENGTH  2
+#define GOT_PAYLOAD 3
+#define GOT_CRC1    4
+
+static struct spprz_transport * get_pprz_trans(struct pprzlink_msg *msg)
+{
+  return (struct pprz_transport *)(msg->trans->impl);
+}
+
+static void accumulate_checksum(struct spprz_transport *trans, const uint8_t byte)
+{
+  trans->ck_a_tx += byte;
+  trans->ck_b_tx += trans->ck_a_tx;
+}
+
+static inline void insert_byte(struct spprz_transport *trans, const uint8_t byte) {
+  trans->tx_msg[trans->tx_msg_idx] = byte;
+  trans->tx_msg_idx++;
+}
+
+static void put_bytes(struct spprz_transport *trans,
+                      struct link_device *dev __attribute__((unused)),
+                      long fd __attribute__((unused)),
+                      enum TransportDataType type __attribute__((unused)),
+                      enum TransportDataFormat format __attribute__((unused)),
+                      const void *bytes, uint16_t len)
+{
+  const uint8_t *b = (const uint8_t *) bytes;
+  int i;
+  for (i = 0; i < len; i++) {
+    insert_byte(trans, b[i]);
+  }
+}
+
+static void put_named_byte(struct spprz_transport *trans,
+                           struct link_device *dev __attribute__((unused)),
+                           long fd __attribute__((unused)),
+                           enum TransportDataType type __attribute__((unused)),
+                           enum TransportDataFormat format __attribute__((unused)),
+                           uint8_t byte,
+                           const char *name __attribute__((unused)))
+{
+  insert_byte(trans, byte);
+}
+
+static uint8_t size_of(struct spprz_transport *trans __attribute__((unused)), uint8_t len)
+{
+  // message length: payload + protocol overhead (STX + len + ck_a + ck_b = 4)
+  return len + 4;
+}
+
+static void start_message(struct spprz_transport *trans,
+                          struct link_device *dev __attribute__((unused)),
+                          long fd __attribute__((unused)),
+                          uint8_t payload_len)
+{
+  PPRZ_MUTEX_LOCK(trans->spprz_mtx_tx); // lock mutex
+  memset(trans->tx_msg, 0, TRANSPORT_PAYLOAD_LEN);
+  trans->tx_msg_idx = 0;
+
+  insert_byte(trans, PPRZ_STX);
+  const uint8_t msg_len = size_of(trans, payload_len);
+  insert_byte(trans, msg_len);
+}
+
+static void end_message(struct spprz_transport *trans, struct link_device *dev, long fd)
+{
+  if (spprz_process_outgoing_packet(trans)) {
+    trans->ck_a_tx = trans->tx_msg[PPRZ_MSG_LEN_IDX];
+    trans->ck_b_tx = trans->tx_msg[PPRZ_MSG_LEN_IDX];
+
+    // send first two bytes
+    dev->put_byte(dev->periph, fd, trans->tx_msg[0]);
+    dev->put_byte(dev->periph, fd, trans->tx_msg[1]);
+
+    // we start counting checksum at byte 2
+    for (uint8_t i=2; i<trans->tx_msg_idx; i++) {
+      accumulate_checksum(trans, trans->tx_msg[i]);
+      dev->put_byte(dev->periph, fd, trans->tx_msg[i]);
+    }
+
+    // append checksum & send message
+    dev->put_byte(dev->periph, fd, trans->ck_a_tx);
+    dev->put_byte(dev->periph, fd, trans->ck_b_tx);
+    dev->send_message(dev->periph, fd);
+  }
+  PPRZ_MUTEX_UNLOCK(trans->spprz_mtx_tx); // unlock mutex
+}
+
+static void overrun(struct spprz_transport *trans __attribute__((unused)), struct link_device *dev)
+{
+  dev->nb_ovrn++;
+}
+
+static void count_bytes(struct spprz_transport *trans __attribute__((unused)),
+                        struct link_device *dev, uint8_t bytes)
+{
+  dev->nb_bytes += bytes;
+}
+
+static int check_available_space(struct spprz_transport *trans __attribute__((unused)),
+                                 struct link_device *dev,
+                                 long *fd, uint16_t bytes)
+{
+  // TODO: might not be necessary
+  return dev->check_free_space(dev->periph, fd, bytes);
+}
+
+// Init pprz transport structure
+void spprz_transport_init(struct spprz_transport *t)
+{
+  t->status = UNINIT;
+  t->trans_rx.msg_received = false;
+  t->trans_tx.size_of = (size_of_t) size_of;
+  t->trans_tx.check_available_space = (check_available_space_t) check_available_space;
+  t->trans_tx.put_bytes = (put_bytes_t) put_bytes;
+  t->trans_tx.put_named_byte = (put_named_byte_t) put_named_byte;
+  t->trans_tx.start_message = (start_message_t) start_message;
+  t->trans_tx.end_message = (end_message_t) end_message;
+  t->trans_tx.overrun = (overrun_t) overrun;
+  t->trans_tx.count_bytes = (count_bytes_t) count_bytes;
+  t->trans_tx.impl = (void *)(t);
+  PPRZ_MUTEX_INIT(t->spprz_mtx_tx); // init mutex, check if correct pointer
+}
+
+
+// Parsing function
+void parse_spprz(struct spprz_transport *t, uint8_t c)
+{
+  switch (t->status) {
+    case UNINIT:
+      switch (c) {
+        case PPRZ_STX:
+          t->status++;
+          t->packet_encrypted = false;
+          break;
+        case PPRZ_STX_SECURE:
+          t->status++;
+          t->packet_encrypted = true;
+          break;
+        default:
+          break;
+      }
+      break;
+    case GOT_STX:
+      if (t->trans_rx.msg_received) {
+        t->trans_rx.ovrn++;
+        goto error;
+      }
+      t->trans_rx.payload_len = c - 4; /* Counting STX, LENGTH and CRC1 and CRC2 */
+      t->ck_a_rx = t->ck_b_rx = c;
+      t->status++;
+      t->payload_idx = 0;
+      break;
+    case GOT_LENGTH:
+      t->trans_rx.payload[t->payload_idx] = c;
+      t->ck_a_rx += c; t->ck_b_rx += t->ck_a_rx;
+      t->payload_idx++;
+      if (t->payload_idx == t->trans_rx.payload_len) {
+        t->status++;
+      }
+      break;
+    case GOT_PAYLOAD:
+      if (c != t->ck_a_rx) {
+        goto error;
+      }
+      t->status++;
+      break;
+    case GOT_CRC1:
+      if (c != t->ck_b_rx) {
+        goto error;
+      }
+      t->trans_rx.msg_received = true;
+      goto restart;
+    default:
+      goto error;
+  }
+  return;
+error:
+  t->trans_rx.error++;
+restart:
+  t->status = UNINIT;
+  return;
+}
+
+
+/** Parsing a frame data and copy the payload to the datalink buffer */
+void spprz_check_and_parse(struct link_device *dev, struct spprz_transport *trans,
+                           uint8_t *buf, bool *msg_available)
+{
+  if (dev->char_available(dev->periph)) {
+    while (dev->char_available(dev->periph) && !trans->trans_rx.msg_received) {
+      parse_spprz(trans, dev->get_byte(dev->periph));
+    }
+    if (trans->trans_rx.msg_received) {
+      if (spprz_process_incoming_packet(trans, buf)) {
+        *msg_available = true;
+      }
+      trans->trans_rx.msg_received = false;
+    }
+  }
+}

--- a/lib/v2.0/C/spprz_transport.h
+++ b/lib/v2.0/C/spprz_transport.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2003  Pascal Brisset, Antoine Drouin
+ * Copyright (C) 2015  Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Copyright (C) 2017 Michal Podhradsky <mpodhradsky@galois.com>
+ *
+ * This file is part of paparazzi.
+ *
+ * paparazzi is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * paparazzi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with paparazzi; see the file COPYING.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @file pprzlink/spprz_transport.h
+ *
+ * Building and parsing secure Paparazzi frames.
+ * Provides only basic hooks, the majority of work (encryption/decryption)
+ * is done in an external user-supplied file.
+ *
+ * Pprz frame:
+ *
+ * |STX|length|... payload=(length-4) bytes ...|Checksum A|Checksum B|
+ *
+ * where checksum is computed over length and payload:
+ * @code
+ * ck_A = ck_B = length
+ * for each byte b in payload
+ *     ck_A += b;
+ *     ck_b += ck_A;
+ * @endcode
+ */
+
+#ifndef SPPRZ_TRANSPORT_H
+#define SPPRZ_TRANSPORT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include "pprzlink/pprzlink_transport.h"
+#include "pprzlink/pprzlink_device.h"
+#include "pprz_mutex.h" // mutex definitions
+
+// Start byte
+#define PPRZ_STX        0x99
+
+/* PPRZ Transport
+ */
+struct spprz_transport {
+  // generic reception interface
+  struct transport_rx trans_rx;
+  // specific pprz transport_rx variables
+  uint8_t status;
+  uint8_t payload_idx;
+  uint8_t ck_a_rx, ck_b_rx;
+
+  // generic transmission interface
+  struct transport_tx trans_tx;
+  // specific pprz transport_tx variables
+  uint8_t ck_a_tx, ck_b_tx;
+  // buffered tx message
+  uint8_t tx_msg[TRANSPORT_PAYLOAD_LEN];
+  volatile uint8_t tx_msg_idx;
+  bool packet_encrypted;
+  PPRZ_MUTEX(spprz_mtx_tx); // mutex is a part of the transport
+};
+
+// include after defining the spprz_stransport struct
+#include "pprzlink/spprz_utils.h"
+
+// Init function
+extern void spprz_transport_init(struct spprz_transport *t);
+
+// Checking new data and parsing
+extern void spprz_check_and_parse(struct link_device *dev, struct spprz_transport *trans, uint8_t *buf, bool *msg_available);
+
+// Parsing function, only needed for modules doing their own parsing
+// without using the pprz_check_and_parse function
+extern void parse_spprz(struct spprz_transport *t, uint8_t c);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* SPPRZ_TRANSPORT_H */
+

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -1982,8 +1982,20 @@
       <field name="bus_number"                  type="uint8"/>
     </message>
 
-  <!-- 254 is free -->
-  <!-- 255 is free -->
+    <message name="KEY_EXCHANGE_UAV" id="254">
+      <description>Message for key exchange during crypto initialization</description>
+      <field name="msg_type" type="uint8" values="P_AE|P_BE|SIG"/>
+      <field name="msg_data" type="uint8[]"/>
+    </message>
+
+    <message name="SPPRZ_STATUS" id="255">
+      <description>Message for monitoring key exchange status</description>
+      <field name="sts_stage" type="uint8" values="INIT|WAIT_MSG1|WAIT_MSG2|WAIT_MSG3|CRYPTO_OK"/>
+      <field name="sts_error" type="uint8" values="NONE|MSG1_TIMEOUT|MSG1_ENCRYPT|MSG3_TIMEOUT|MSG3_DECRYPT|MSG3_SIGNVERIFY|MSG2_TIMEOUT|MSG2_DECRYPT|MSG2_SIGNVERIFY|MSG3_ENCRYPT|UNEXPECTED_TYPE|UNEXPECTED_STAGE|UNEXPECTED_MSG"/>
+      <field name="counter_err"      type="uint32"/>
+      <field name="decrypt_err"      type="uint32"/>
+      <field name="encrypt_err"      type="uint32"/>
+    </message>
 
   </msg_class>
 
@@ -2461,6 +2473,12 @@
     <message name="RTCM_INJECT" id="157" link="broadcasted">
       <field name="packet_id" type="uint8"/>
       <field name="data" type="uint8[]"/>
+    </message>
+
+    <message name="KEY_EXCHANGE_GCS" id="159">
+      <description>Message for key exchange during crypto initialization</description>
+      <field name="msg_type" type="uint8" values="P_AE|P_BE|SIG"/>
+      <field name="msg_data" type="uint8[]"/>
     </message>
 
   </msg_class>


### PR DESCRIPTION
This PR adds a general template for secure (encrypted/authenticated) pprzlink.

The idea is simple - secure transport doesn't put bytes directly to the link device, but saves them in a local buffer until `end_message()` is called. 

At that point, the buffer is passed to `spprz_process_outgoing_packet()` which is defined externally (a minimal weak implementation if provided). If `spprz_process_outgoing_packet()` returns true, the packet is sent.

Similarly for the incoming packets (see `spprz_utils.h` for detailed description). `spprz_utils.c` provide just a trivial weak implementation for demonstration purposes, and should not be used for real application.

The advantage is that pprzink doesn't constrain what encryption/authentication schema can be used, as this is all up to the user. So no additional files / libraries/ etc are needed for pprzlink itself.
