### PR TITLE
message for taking over INDI guidance from ground

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2105,7 +2105,7 @@
       <field name="ac_id"  type="uint8"/>
     </message>
 
-   <message name="DESIDED_SET_POINT" id="15" link="forwarded">
+   <message name="DESIRED_SET_POINT" id="15" link="forwarded">
      <description>This message is used to set 3D desired vehicle's states such as accelerations or velocities.</description>
      <field name="ac_id" type= "uint8">AC_ID of the vehicle</field>
      <field name="flag" type= "uint8">Up to the user, for example to distinguish between ENU or NED.</field>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2105,6 +2105,15 @@
       <field name="ac_id"  type="uint8"/>
     </message>
 
+   <message name="FC_ROTOR" id="15" link="forwarded">
+     <description>If a vehicle is running the guidance_INDI and receives this message, then it tracks the accelerations provided from the ground.</description>
+     <field name="ac_id" type= "uint8">AC_ID of the vehicle</field>
+     <field name="dim" type= "uint8" values="0|1">If 0 the vehicles ommits the provided acceleration in the z axis (the vertical axis is controlled by the on-board guidance). If 1 the vehicle tracks the provided 3D acceleration</field>
+     <field name="ux" type= "float" unit="m/s^2">Acceleration to be tracked in the X axis</field>
+     <field name="uy" type= "float" unit="m/s^2">Acceleration to be tracked in the Y axis</field>
+     <field name="uz" type= "float" unit="m/s^2">Acceleration to be tracked in the Z axis. Omitted if dim is equal to 0.</field>
+   </message>
+
     <message name="GET_SETTING" id="16" link="forwarded">
       <field name="index" type="uint8"/>
       <field name="ac_id" type="uint8"/>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2105,13 +2105,13 @@
       <field name="ac_id"  type="uint8"/>
     </message>
 
-   <message name="FC_ROTOR" id="15" link="forwarded">
-     <description>If a vehicle is running the guidance_INDI and receives this message, then it tracks the accelerations provided from the ground.</description>
+   <message name="DESIDED_SET_POINT" id="15" link="forwarded">
+     <description>This message is used to set 3D desired vehicle's states such as accelerations or velocities.</description>
      <field name="ac_id" type= "uint8">AC_ID of the vehicle</field>
-     <field name="dim" type= "uint8" values="0|1">If 0 the vehicles ommits the provided acceleration in the z axis (the vertical axis is controlled by the on-board guidance). If 1 the vehicle tracks the provided 3D acceleration</field>
-     <field name="ux" type= "float" unit="m/s^2">Acceleration to be tracked in the X axis</field>
-     <field name="uy" type= "float" unit="m/s^2">Acceleration to be tracked in the Y axis</field>
-     <field name="uz" type= "float" unit="m/s^2">Acceleration to be tracked in the Z axis. Omitted if dim is equal to 0.</field>
+     <field name="flag" type= "uint8">Up to the user, for example to distinguish between ENU or NED.</field>
+     <field name="ux" type= "float">Quantity to be tracked in the X axis.</field>
+     <field name="uy" type= "float">Quantity to be tracked in the Y axis.</field>
+     <field name="uz" type= "float">Quantity to be tracked in the Z axis.</field>
    </message>
 
     <message name="GET_SETTING" id="16" link="forwarded">


### PR DESCRIPTION
One can control a vehicle from the ground by overriding the on-board INDI guidance with this message. 
For example, we use this for the formation control of different rotorcraft where all the desired accelerations are calculated on the ground.