### PR TITLE
Ocaml 405 fix pprzlink

### DIFF
--- a/lib/common/ocaml/Makefile
+++ b/lib/common/ocaml/Makefile
@@ -55,6 +55,9 @@ BUILDDIR ?= $(PPRZLINK_DIR)/build/ocaml/pprzlink
 ifeq ($(shell test $(OCAMLC_MINOR) -ge 2; echo $$?),0)
 # the Bytes module is available since OCaml 4.02.0
 CAMLP4_DEFS += -DHAS_BYTES_MODULE
+ifeq ($(shell test $(OCAMLC_MINOR) -ge 4; echo $$?),0)
+CAMLP4_DEFS += -DOCAML_V404
+endif
 endif
 endif
 

--- a/lib/common/ocaml/compatPL.ml
+++ b/lib/common/ocaml/compatPL.ml
@@ -28,7 +28,6 @@
  module BYTES = String
  END
 
-
 let bytes_create = fun len ->
   BYTES.create len
 
@@ -72,35 +71,17 @@ let bytes_iter = fun f s->
   BYTES.iter f s
 
 IFDEF OCAML_V404 THEN
-let string_lowercase = fun s ->
-  String.lowercase_ascii s
- 
-let string_uppercase = fun s ->
-  String.uppercase_ascii s
- 
-let string_capitalize = fun s ->
-  String.capitalize_ascii s
- 
-let bytes_lowercase = fun s->
-  BYTES.lowercase_ascii s
- 
-let bytes_uppercase = fun s->
-  BYTES.uppercase_ascii s
- 
+let lowercase_ascii = BYTES.lowercase_ascii
+
+let uppercase_ascii = BYTES.uppercase_ascii
+
+let capitalize_ascii = BYTES.capitalize_ascii
+
 ELSE
-let string_lowercase = fun s ->
-  String.lowercase s
- 
-let string_uppercase = fun s ->
-  String.uppercase s
- 
-let string_capitalize = fun s ->
-  String.capitalize s
- 
-let bytes_lowercase = fun s->
-  BYTES.lowercase s
- 
-let bytes_uppercase = fun s->
-  BYTES.uppercase s
- 
+let lowercase_ascii = BYTES.lowercase
+
+let uppercase_ascii = BYTES.uppercase
+
+let capitalize_ascii = BYTES.capitalize
+
 END

--- a/lib/common/ocaml/compatPL.ml
+++ b/lib/common/ocaml/compatPL.ml
@@ -28,6 +28,7 @@
  module BYTES = String
  END
 
+
 let bytes_create = fun len ->
   BYTES.create len
 
@@ -42,12 +43,6 @@ let bytes_make = fun n c->
 
 let bytes_copy = fun s->
   BYTES.copy s
-
-let bytes_lowercase = fun s->
-  BYTES.lowercase s
-
-let bytes_uppercase = fun s->
-  BYTES.uppercase s
 
 let bytes_blit = fun src srcoff dst dstoff len->
   BYTES.blit src srcoff dst dstoff len
@@ -75,3 +70,37 @@ let bytes_set = fun s n c->
 
 let bytes_iter = fun f s->
   BYTES.iter f s
+
+IFDEF OCAML_V404 THEN
+let string_lowercase = fun s ->
+  String.lowercase_ascii s
+ 
+let string_uppercase = fun s ->
+  String.uppercase_ascii s
+ 
+let string_capitalize = fun s ->
+  String.capitalize_ascii s
+ 
+let bytes_lowercase = fun s->
+  BYTES.lowercase_ascii s
+ 
+let bytes_uppercase = fun s->
+  BYTES.uppercase_ascii s
+ 
+ELSE
+let string_lowercase = fun s ->
+  String.lowercase s
+ 
+let string_uppercase = fun s ->
+  String.uppercase s
+ 
+let string_capitalize = fun s ->
+  String.capitalize s
+ 
+let bytes_lowercase = fun s->
+  BYTES.lowercase s
+ 
+let bytes_uppercase = fun s->
+  BYTES.uppercase s
+ 
+END

--- a/lib/common/ocaml/compatPL.mli
+++ b/lib/common/ocaml/compatPL.mli
@@ -27,8 +27,6 @@ val bytes_contains : string -> char -> bool
 val bytes_length : string -> int
 val bytes_make : int -> char -> string
 val bytes_copy : string -> string
-val bytes_lowercase : string -> string
-val bytes_uppercase : string -> string
 val bytes_blit : string -> int -> string -> int -> int -> unit
 val bytes_sub : string -> int -> int -> string
 val bytes_index : string -> char -> int
@@ -39,7 +37,6 @@ val bytes_compare : string -> string -> int
 val bytes_set : string -> int -> char -> unit
 val bytes_iter : (char -> unit) -> string -> unit
 
-val string_lowercase : string -> string
-val string_uppercase : string -> string
-val string_capitalize : string -> string
-
+val lowercase_ascii : string -> string
+val uppercase_ascii : string -> string
+val capitalize_ascii : string -> string

--- a/lib/common/ocaml/compatPL.mli
+++ b/lib/common/ocaml/compatPL.mli
@@ -38,3 +38,8 @@ val bytes_get : string -> int -> char
 val bytes_compare : string -> string -> int
 val bytes_set : string -> int -> char -> unit
 val bytes_iter : (char -> unit) -> string -> unit
+
+val string_lowercase : string -> string
+val string_uppercase : string -> string
+val string_capitalize : string -> string
+

--- a/lib/v1.0/ocaml/pprzLink.ml
+++ b/lib/v1.0/ocaml/pprzLink.ml
@@ -245,7 +245,7 @@ let scale_of_units = fun ?auto from_unit to_unit ->
       float_of_string (Xml.attrib _unit "coef")
     with Xml.File_not_found _ -> raise (Unit_conversion_error ("Parse error of conf/units.xml"))
       | Xml.No_attribute _ | Xml.Not_element _ -> raise (Unit_conversion_error ("File conf/units.xml has errors"))
-      | Failure "float_of_string" -> raise (Unit_conversion_error ("Unit coef is not numerical value"))
+      | Failure _ -> raise (Unit_conversion_error ("Unit coef is not numerical value"))
       | Not_found ->
         if from_unit = "" || to_unit = "" then raise (No_automatic_conversion (from_unit, to_unit))
         else raise (Unknown_conversion (from_unit, to_unit))
@@ -311,7 +311,7 @@ let xml_child xml ?select c =
   let children = Xml.children xml in
   (* Let's try with a numeric index *)
   try (Array.of_list children).(Pervasives.int_of_string c) with
-    Failure "int_of_string" -> (* Bad luck. Go through the children *)
+    Failure _ -> (* Bad luck. Go through the children *)
       find children
 
 let pipe_regexp = Str.regexp "|"
@@ -625,7 +625,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
             (field_name, value) :: loop (index+n) fs in
       (id, ac_id, loop offset_fields message.fields)
     with
-        Invalid_argument("index out of bounds") ->
+        Invalid_argument _ ->
           failwith (sprintf "PprzLink.values_of_payload, wrong argument: %s" (DebugPL.xprint buffer))
 
 
@@ -676,7 +676,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
               let values = List.map2 (fun (field_name, field) v -> (field_name, value field._type v)) msg.fields args in
               (msg_id, values)
             with
-                Invalid_argument "List.map2" -> failwith (sprintf "PprzLink.values_of_string: incorrect number of fields in '%s'" s)
+                Invalid_argument _ -> failwith (sprintf "PprzLink.values_of_string: incorrect number of fields in '%s'" s)
           end
       | [] -> invalid_arg (sprintf "PprzLink.values_of_string: %s" s)
 

--- a/lib/v1.0/ocaml/pprzLink.ml
+++ b/lib/v1.0/ocaml/pprzLink.ml
@@ -237,7 +237,7 @@ let scale_of_units = fun ?auto from_unit to_unit ->
         and a = try Some (Xml.attrib u "auto") with _ -> None in
         let a = match auto, a with
           | Some _, None | None, None -> "" (* No auto conversion *)
-          | Some t, Some _ | None, Some t -> CompatPL.bytes_lowercase t (* param auto is used before attribute *)
+          | Some t, Some _ | None, Some t -> CompatPL.lowercase_ascii t (* param auto is used before attribute *)
         in
         if (f = from_unit || a = "display") && (t = to_unit || a = "code") then true else false
       ) (Xml.children units_xml) in
@@ -324,14 +324,14 @@ let field_of_xml = fun xml ->
   let auc = alt_unit_coef_of_xml xml in
   let values = try Str.split pipe_regexp (Xml.attrib xml "values") with _ -> [] in
 
-  ( CompatPL.bytes_lowercase (xml_attrib xml "name"),
+  ( CompatPL.lowercase_ascii (xml_attrib xml "name"),
     { _type = t; fformat = f; alt_unit_coef = auc; enum=values })
 
 let string_of_values = fun vs ->
   CompatPL.bytes_concat " " (List.map (fun (a,v) -> sprintf "%s=%s" a (string_of_value v)) vs)
 
 let assoc = fun a vs ->
-  try List.assoc (CompatPL.bytes_lowercase a) vs with Not_found ->
+  try List.assoc (CompatPL.lowercase_ascii a) vs with Not_found ->
     failwith (sprintf "Attribute '%s' not found in '%s'" a (string_of_values vs))
 
 let float_assoc = fun (a:string) vs ->

--- a/lib/v2.0/ocaml/pprzLink.ml
+++ b/lib/v2.0/ocaml/pprzLink.ml
@@ -248,7 +248,7 @@ let scale_of_units = fun ?auto from_unit to_unit ->
       float_of_string (Xml.attrib _unit "coef")
     with Xml.File_not_found _ -> raise (Unit_conversion_error ("Parse error of conf/units.xml"))
       | Xml.No_attribute _ | Xml.Not_element _ -> raise (Unit_conversion_error ("File conf/units.xml has errors"))
-      | Failure "float_of_string" -> raise (Unit_conversion_error ("Unit coef is not numerical value"))
+      | Failure _ -> raise (Unit_conversion_error ("Unit coef is not numerical value"))
       | Not_found ->
         if from_unit = "" || to_unit = "" then raise (No_automatic_conversion (from_unit, to_unit))
         else raise (Unknown_conversion (from_unit, to_unit))
@@ -314,7 +314,7 @@ let xml_child xml ?select c =
   let children = Xml.children xml in
   (* Let's try with a numeric index *)
   try (Array.of_list children).(Pervasives.int_of_string c) with
-    Failure "int_of_string" -> (* Bad luck. Go through the children *)
+    Failure _ -> (* Bad luck. Go through the children *)
       find children
 
 let pipe_regexp = Str.regexp "|"
@@ -647,7 +647,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
             (field_name, value) :: loop (index+n) fs in
       (id, sender_id, loop offset_fields message.fields)
     with
-        Invalid_argument("index out of bounds") ->
+        Invalid_argument _ ->
           failwith (sprintf "PprzLink.values_of_payload, wrong argument: %s" (DebugPL.xprint buffer))
 
 
@@ -701,7 +701,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
               let values = List.map2 (fun (field_name, field) v -> (field_name, value field._type v)) msg.fields args in
               (msg_id, values)
             with
-                Invalid_argument "List.map2" -> failwith (sprintf "PprzLink.values_of_string: incorrect number of fields in '%s'" s)
+                Invalid_argument _ -> failwith (sprintf "PprzLink.values_of_string: incorrect number of fields in '%s'" s)
           end
       | [] -> invalid_arg (sprintf "PprzLink.values_of_string: %s" s)
 

--- a/lib/v2.0/ocaml/pprzLink.ml
+++ b/lib/v2.0/ocaml/pprzLink.ml
@@ -240,7 +240,7 @@ let scale_of_units = fun ?auto from_unit to_unit ->
         and a = try Some (Xml.attrib u "auto") with _ -> None in
         let a = match auto, a with
           | Some _, None | None, None -> "" (* No auto conversion *)
-          | Some t, Some _ | None, Some t -> CompatPL.bytes_lowercase t (* param auto is used before attribute *)
+          | Some t, Some _ | None, Some t -> CompatPL.lowercase_ascii t (* param auto is used before attribute *)
         in
         if (f = from_unit || a = "display") && (t = to_unit || a = "code") then true else false
       ) (Xml.children units_xml) in
@@ -327,14 +327,14 @@ let field_of_xml = fun xml ->
   let auc = alt_unit_coef_of_xml xml in
   let values = try Str.split pipe_regexp (Xml.attrib xml "values") with _ -> [] in
 
-  ( CompatPL.bytes_lowercase (xml_attrib xml "name"),
+  ( CompatPL.lowercase_ascii (xml_attrib xml "name"),
     { _type = t; fformat = f; alt_unit_coef = auc; enum=values })
 
 let string_of_values = fun vs ->
   CompatPL.bytes_concat " " (List.map (fun (a,v) -> sprintf "%s=%s" a (string_of_value v)) vs)
 
 let assoc = fun a vs ->
-  try List.assoc (CompatPL.bytes_lowercase a) vs with Not_found ->
+  try List.assoc (CompatPL.lowercase_ascii a) vs with Not_found ->
     failwith (sprintf "Attribute '%s' not found in '%s'" a (string_of_values vs))
 
 let float_assoc = fun (a:string) vs ->


### PR DESCRIPTION
Various ocaml fixes for ocaml build warnings.

Warning 52 was fixed by running the exception for all the possible cases. Most of these were for fairly trivial errors ie:
Failure ("int_of_string")  changed to Failure _

Code was tested with ocaml 4.01, 4.02, 4.04 and 4.05.

See https://github.com/paparazzi/paparazzi/pull/2221
and https://github.com/paparazzi/paparazzi/issues/2140