### PR TITLE
fix acces to unaligned arrays in v2.0

### DIFF
--- a/tools/generator/C/include_v2.0/pprzlink_utils.h
+++ b/tools/generator/C/include_v2.0/pprzlink_utils.h
@@ -76,14 +76,6 @@ typedef union __attribute__((packed)) {
   uint64_t  uint64;
   float     f32;
   double    f64;
-  int16_t*  int16_p;
-  uint16_t* uint16_p;
-  int32_t*  int32_p;
-  uint32_t* uint32_p;
-  int64_t*  int64_p;
-  uint64_t* uint64_p;
-  float*    f32_p;
-  double*   f64_p;
 } unaligned_t;
 
 #define _PPRZ_VAL_int16_t(_payload, _offset) (((unaligned_t*)(_payload+_offset))->int16)
@@ -104,14 +96,14 @@ typedef union __attribute__((packed)) {
 #endif
 
 // In this case, data is not aligned but we are still able to read them
-#define _PPRZ_VAL_int16_t_array(_payload, _offset) (((unaligned_t*)(_payload+_offset))->int16_p)
-#define _PPRZ_VAL_uint16_t_array(_payload, _offset) (((unaligned_t*)(_payload+_offset))->uint16_p)
-#define _PPRZ_VAL_int32_t_array(_payload, _offset) (((unaligned_t*)(_payload+_offset))->int32_p)
-#define _PPRZ_VAL_uint32_t_array(_payload, _offset) (((unaligned_t*)(_payload+_offset))->uint32_p)
-#define _PPRZ_VAL_int64_t_array(_payload, _offset) (((unaligned_t*)(_payload+_offset))->int64_p)
-#define _PPRZ_VAL_uint64_t_array(_payload, _offset) (((unaligned_t*)(_payload+_offset))->uint64_p)
-#define _PPRZ_VAL_float_array(_payload, _offset) (((unaligned_t*)(_payload+_offset))->f32_p)
-#define _PPRZ_VAL_double_array(_payload, _offset) (((unaligned_t*)(_payload+_offset))->f64_p)
+#define _PPRZ_VAL_int16_t_array(_payload, _offset) ((int16_t*)(_payload+_offset))
+#define _PPRZ_VAL_uint16_t_array(_payload, _offset) ((uint16_t*)(_payload+_offset))
+#define _PPRZ_VAL_int32_t_array(_payload, _offset) ((int32_t*)(_payload+_offset))
+#define _PPRZ_VAL_uint32_t_array(_payload, _offset) ((uint32_t*)(_payload+_offset))
+#define _PPRZ_VAL_int64_t_array(_payload, _offset) ((int64_t*)(_payload+_offset))
+#define _PPRZ_VAL_uint64_t_array(_payload, _offset) ((uint64_t*)(_payload+_offset))
+#define _PPRZ_VAL_float_array(_payload, _offset) ((float*)(_payload+_offset))
+#define _PPRZ_VAL_double_array(_payload, _offset) ((double*)(_payload+_offset))
 #define _PPRZ_VAL_len_aligned(_payload, _offset) _PPRZ_VAL_uint8_t(_payload, _offset)
 #define _PPRZ_VAL_fixed_len_aligned(_len) (_len)
 

--- a/tools/generator/C/include_v2.0/pprzlink_utils.h
+++ b/tools/generator/C/include_v2.0/pprzlink_utils.h
@@ -96,14 +96,14 @@ typedef union __attribute__((packed)) {
 #endif
 
 // In this case, data is not aligned but we are still able to read them
-#define _PPRZ_VAL_int16_t_array(_payload, _offset) ((int16_t*)(_payload+_offset))
-#define _PPRZ_VAL_uint16_t_array(_payload, _offset) ((uint16_t*)(_payload+_offset))
-#define _PPRZ_VAL_int32_t_array(_payload, _offset) ((int32_t*)(_payload+_offset))
-#define _PPRZ_VAL_uint32_t_array(_payload, _offset) ((uint32_t*)(_payload+_offset))
-#define _PPRZ_VAL_int64_t_array(_payload, _offset) ((int64_t*)(_payload+_offset))
-#define _PPRZ_VAL_uint64_t_array(_payload, _offset) ((uint64_t*)(_payload+_offset))
-#define _PPRZ_VAL_float_array(_payload, _offset) ((float*)(_payload+_offset))
-#define _PPRZ_VAL_double_array(_payload, _offset) ((double*)(_payload+_offset))
+#define _PPRZ_VAL_int16_t_array(_payload, _offset) (&_PPRZ_VAL_int16_t(_payload, _offset))
+#define _PPRZ_VAL_uint16_t_array(_payload, _offset) (&_PPRZ_VAL_uint16_t(_payload, _offset))
+#define _PPRZ_VAL_int32_t_array(_payload, _offset) (&_PPRZ_VAL_int32_t(_payload, _offset))
+#define _PPRZ_VAL_uint32_t_array(_payload, _offset) (&_PPRZ_VAL_uint32_t(_payload, _offset))
+#define _PPRZ_VAL_int64_t_array(_payload, _offset) (&_PPRZ_VAL_int64_t(_payload, _offset))
+#define _PPRZ_VAL_uint64_t_array(_payload, _offset) (&_PPRZ_VAL_uint64_t(_payload, _offset))
+#define _PPRZ_VAL_float_array(_payload, _offset) (&_PPRZ_VAL_float(_payload, _offset))
+#define _PPRZ_VAL_double_array(_payload, _offset) (&_PPRZ_VAL_double(_payload, _offset))
 #define _PPRZ_VAL_len_aligned(_payload, _offset) _PPRZ_VAL_uint8_t(_payload, _offset)
 #define _PPRZ_VAL_fixed_len_aligned(_len) (_len)
 


### PR DESCRIPTION
Access to unaligned array seems wrong (see #80). This fix reverts back to the solution using in v1.0 that was correct. What is currently done is interpreting the content of the array as a pointer value, which is not what we want.