### PR TITLE
Xbee selecting channel number 0 leaves channel unchanged.

### DIFF
--- a/lib/common/ocaml/xbee_transport.ml
+++ b/lib/common/ocaml/xbee_transport.ml
@@ -169,8 +169,11 @@ let at_set_baud_rate = fun baud ->
       Not_found -> invalid_arg "at_set_baud_rate"
 
 let at_set_channel = fun ch ->
-  assert (ch >= 0x0C && ch <= 0x17);
-  Printf.sprintf "ATCH%X\r" ch
+  match ch with
+       0 -> ""
+    |  c ->
+        assert (ch >= 0x0C && ch <= 0x17);
+        Printf.sprintf "ATCH%X\r" c
 
 let at_exit = "ATCN\r"
 let at_api_enable = "ATAP1\r"


### PR DESCRIPTION
Improves previous commit : selecting in-existing channel 0 will not change channel configuration of the modem.
It will be the default behavior.

@dewagter It will be used for the default behavior of paparazzi/paparazzi#2288