### PR TITLE
[ublox] Retrieve information about GPS version and configuration

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -612,7 +612,16 @@
       <field name="GX3_chksm"	type="uint16"/>
     </message>
 
-    <!-- 74 is free -->
+    <message name="UBLOX_INFO" id="74">
+      <field name="baud"  type="uint32" />
+      <field name="ver_sw_h"  type="uint8" />
+      <field name="ver_sw_l"  type="uint8" />
+      <field name="ver_hw_h"  type="uint16" />
+      <field name="ver_hw_l"  type="uint16" />
+      <field name="sbas"  type="uint8" />
+      <field name="gnss"  type="uint8" values="NONE|GPS|GLONAS|GPS+GLONAS|BEIDOU|GPS+BEIDOU|GLONAS+BEIDOU|GPS+GLONAS+BEIDOU|GALILEO"/>
+    </message>
+
     <!-- 75 is free -->
     <!-- 76 is free -->
     <!-- 77 is free -->


### PR DESCRIPTION
Since the Ublox 7 series, several constellations are supported.
Since the Ublox 8 series, constellations can be enabled at the same time.
It now becomes important to know which version is in your plane and which constellation is activated.
A dedicated message will be sent on startup.