### PR TITLE
update voltage to float

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -109,15 +109,13 @@
       <field name="mcu1_status" type="uint8" values="LOST|OK|REALLY_LOST"/>
     </message>
 
-    <message name="BAT" id="12">
-      <field name="throttle" type="int16" unit="pprz"/>
-      <field name="voltage" type="uint16" unit="1e-1V" alt_unit="V" alt_unit_coef="0.1"/>
-      <field name="amps" type="int16" unit="1e-2A" alt_unit="A" alt_unit_coef="0.01"/>
-      <field name="flight_time" type="uint16" unit="s"/>
-      <field name="kill_auto_throttle" type="uint8" unit="bool"/>
-      <field name="block_time" type="uint16" unit="s"/>
-      <field name="stage_time" type="uint16" unit="s"/>
-      <field name="energy" type="int16" unit="mAh"/>
+    <message name="ENERGY" id="12">
+      <field name="throttle" type="uint8" unit="%">Throttle setting</field>
+      <field name="voltage"  type="float" unit="V">Input battery voltage</field>
+      <field name="current"  type="float" unit="A">Current consumption</field>
+      <field name="power"    type="float" unit="W">Electrical power</field>
+      <field name="charge"   type="float" unit="Ah">Accumulated consumed charge</field>
+      <field name="energy"   type="float" unit="Wh">Accumulated consumed energy</field>
     </message>
 
     <message name="DEBUG_MCU_LINK" id="13">
@@ -291,7 +289,7 @@
 
     <message name="MOTOR" id="34">
       <field name="rpm" type="uint16" unit="Hz"/>
-      <field name="current" type="int32" unit="mA"/>
+      <field name="current" type="float" unit="A"/>
     </message>
 
     <message name="WP_MOVED" id="35">
@@ -312,12 +310,7 @@
       <field name="temp" type="int8" unit="deg"/>
     </message>
 
-    <message name="ENERGY" id="37">
-      <field name="bat"      type="float" unit="V"/>
-      <field name="amp"      type="float" unit="A"/>
-      <field name="energy"   type="uint16" unit="mAh"/>
-      <field name="power"   type="float" unit="W"/>
-    </message>
+    <!-- 38 is free -->
 
     <message name="DRAGSPEED" id="38">
       <description>
@@ -655,16 +648,16 @@
     <!-- 80 is free -->
 
     <message name="GENERIC_COM" id="81">
-      <field name="lat" type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
-      <field name="lon" type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
-      <field name="alt" type="int16" unit="m"/>
-      <field name="gspeed" type="uint16" unit="cm/s" alt_unit="m/s"/>
-      <field name="course" type="int16" unit="decideg" alt_unit="deg"/>
+      <field name="lat"      type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
+      <field name="lon"      type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
+      <field name="alt"      type="int16" unit="m"/>
+      <field name="gspeed"   type="uint16" unit="cm/s" alt_unit="m/s"/>
+      <field name="course"   type="int16" unit="decideg" alt_unit="deg"/>
       <field name="airspeed" type="uint16" unit="cm/s" alt_unit="m/s"/>
-      <field name="vsupply" type="uint8" unit="decivolt"/>
-      <field name="energy" type="uint8" unit="deciAh"/>
+      <field name="vsupply"  type="uint8" unit="deciV"/>
+      <field name="charge"   type="uint8" unit="deciAh"/>
       <field name="throttle" type="uint8" unit="%"/>
-      <field name="ap_mode" type="uint8"/>
+      <field name="ap_mode"  type="uint8"/>
       <field name="nav_block" type="uint8"/>
       <field name="flight_time" type="uint16" unit="s"/>
     </message>
@@ -811,8 +804,8 @@
       <field name="rc_status" type="uint8" values="OK|LOST|REALLY_LOST"/>
       <field name="frame_rate" type="uint8" unit="Hz"/>
       <field name="mode" type="uint8" values="MANUAL|AUTO|FAILSAFE"/>
-      <field name="vsupply" type="uint16" unit="decivolt"/>
-      <field name="current" type="int32" unit="mA"/>
+      <field name="vsupply" type="float" unit="V"/>
+      <field name="current" type="float" unit="A"/>
     </message>
 
   <!-- Only used in airborne/test/mcu_periph/test_adc.c -->
@@ -1624,7 +1617,7 @@
       <field name="mx" type="int32" unit="adc"/>
       <field name="my" type="int32" unit="adc"/>
       <field name="mz" type="int32" unit="adc"/>
-      <field name="electrical_current" type="int32" unit="mA"/>
+      <field name="electrical_current" type="float" unit="A"/>
     </message>
 
     <message name="UART_ERRORS" id="208">
@@ -1806,8 +1799,8 @@
       <field name="gps_status"   type="uint8" values="NO_FIX|NA|2D|3D|DGPS|RTK"/>
       <field name="ap_mode"      type="uint8">Rover AP modes are generated from XML file</field>
       <field name="ap_motors_on" type="uint8" values="MOTORS_OFF|MOTORS_ON"/>
-      <field name="vsupply"      type="uint16" unit="decivolt"/>
       <field name="cpu_time"     type="uint16" unit="s"/>
+      <field name="vsupply"      type="float" unit="V"/>
     </message>
 
     <message name="ROTORCRAFT_STATUS" id="231">
@@ -1822,8 +1815,8 @@
       <field name="arming_status" type="uint8" values="NO_RC|WAITING|ARMING|ARMED|DISARMING|KILLED|YAW_CENTERED|THROTTLE_DOWN|NOT_MODE_MANUAL|UNARMED_IN_AUTO|THROTTLE_NOT_DOWN|STICKS_NOT_CENTERED|PITCH_NOT_CENTERED|ROLL_NOT_CENTERED|YAW_NOT_CENTERED|AHRS_NOT_ALLIGNED|OUT_OF_GEOFENCE|LOW_BATTERY"/>
       <field name="ap_h_mode"    type="uint8" values="KILL|RATE|ATTITUDE|HOVER|NAV|RC_DIRECT|CF|FORWARD|MODULE|FLIP|GUIDED"/>
       <field name="ap_v_mode"    type="uint8" values="KILL|RC_DIRECT|RC_CLIMB|CLIMB|HOVER|NAV|MODULE|FLIP|GUIDED"/>
-      <field name="vsupply"      type="uint16" unit="decivolt"/>
       <field name="cpu_time"     type="uint16" unit="s"/>
+      <field name="vsupply"      type="float" unit="V"/>
     </message>
 
     <message name="STATE_FILTER_STATUS" id="232">
@@ -2661,11 +2654,11 @@
       <field name="ac_id" type="string"/>
       <field name="throttle" type="float" unit="%"  format="%.1f"/>
       <field name="throttle_accu" type="float" format="%.1f"/>
-      <field name="rpm"      type="float" unit="rpm"  format="%.1f"/>
-      <field name="temp"     type="float" unit="celcius"/>
-      <field name="bat"      type="float" unit="V"/>
-      <field name="amp"      type="float" unit="A"/>
-      <field name="energy"   type="uint16" unit="Wh"/>
+      <field name="rpm"      type="float" unit="rpm" format="%.1f"/>
+      <field name="temp"     type="float" unit="C"/>
+      <field name="bat"      type="float" unit="V" format="%.2f"/>
+      <field name="amp"      type="float" unit="A" format="%.1f"/>
+      <field name="charge"   type="float" unit="Ah" format="%.2f"/>
     </message>
 
     <message name="SVSINFO" id="16">
@@ -2968,8 +2961,8 @@
       <field name="mode" type="uint8" values="MANUAL|AUTO|FAILSAFE"/>
       <field name="rc_status" type="uint8" values="OK|LOST|REALLY_LOST"/>
       <field name="frame_rate" type="uint8" unit="Hz"/>
-      <field name="vsupply" type="uint16" unit="decivolt"/>
-      <field name="current" type="int32" unit="mA"/>
+      <field name="vsupply" type="float" unit="V"/>
+      <field name="current" type="float" unit="A"/>
     </message>
 
     <message name="IMCU_REMOTE_MAG" id="10">


### PR DESCRIPTION
Merge BAT and ENERGY messages. Upgrade battery voltage, used charge to float and add energy field.  The term Energy was sometimes wrongly used when Charge should have so I updated this where necessary.

This is required for paparazzi #2360