### PR TITLE
Add GROUND_GPS message

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2480,7 +2480,7 @@
       <field name="course"  type="float" unit="deg"/>
     </message>
 
-    <message name="GROUND_GPS" id="57" link="forwarded">
+    <message name="TARGET_POS" id="57" link="forwarded">
       <description>
         Ground station GPS position for functions like Follow Me
       </description>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2485,6 +2485,7 @@
         Ground station GPS position for functions like Follow Me
       </description>
       <field name="ac_id" type="uint8"/>
+      <field name="target_id" type="uint8"/>
       <field name="lat" type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
       <field name="lon" type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
       <field name="alt" type="int32" unit="mm" alt_unit="m">Height above Mean Sea Level (geoid)</field>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2480,6 +2480,18 @@
       <field name="course"  type="float" unit="deg"/>
     </message>
 
+    <message name="GROUND_GPS" id="57" link="forwarded">
+      <description>
+        Ground station GPS position for functions like Follow Me
+      </description>
+      <field name="ac_id" type="uint8"/>
+      <field name="lat" type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
+      <field name="lon" type="int32" unit="1e7deg" alt_unit="deg" alt_unit_coef="0.0000001"/>
+      <field name="alt" type="int32" unit="mm" alt_unit="m">Height above Mean Sea Level (geoid)</field>
+      <field name="speed" type="float" unit="m/s">Ground speed</field>
+      <field name="climb" type="float" unit="m/s">Climb speed</field>
+      <field name="course" type="float" unit="deg" format="%.1f"/>
+    </message>
 
     <message name="KITE_COMMAND" id="96">
       <field name="POWER"     type="uint16"/>

--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2482,7 +2482,7 @@
 
     <message name="TARGET_POS" id="57" link="forwarded">
       <description>
-        Ground station GPS position for functions like Follow Me
+        Global position, speed and ID a target for functions like Follow Me
       </description>
       <field name="ac_id" type="uint8"/>
       <field name="target_id" type="uint8"/>


### PR DESCRIPTION
This adds a message with a ground GPS which is forwarded to the aircraft from the GCS.