### PR TITLE
Use directly Bytes module instead of CompatPL

### DIFF
--- a/lib/common/ocaml/compatPL.ml
+++ b/lib/common/ocaml/compatPL.ml
@@ -22,66 +22,18 @@
  *
  *)
 
- IFDEF HAS_BYTES_MODULE THEN
- module BYTES = Bytes
- ELSE
- module BYTES = String
- END
-
-let bytes_create = fun len ->
-  BYTES.create len
-
-let bytes_contains = fun c s ->
-  BYTES.contains c s
-
-let bytes_length = fun len ->
-  BYTES.length len
-
-let bytes_make = fun n c->
-  BYTES.make n c
-
-let bytes_copy = fun s->
-  BYTES.copy s
-
-let bytes_blit = fun src srcoff dst dstoff len->
-  BYTES.blit src srcoff dst dstoff len
-
-let bytes_sub = fun s start len->
-  BYTES.sub s start len
-
-let bytes_index = fun c s ->
-  BYTES.index c s
-
-let bytes_concat = fun sep sl->
-  BYTES.concat sep sl
-
-let bytes_index_from = fun s i c ->
-  BYTES.index_from s i c
-
-let bytes_get = fun s n->
-  BYTES.get s n
-
-let bytes_compare = fun s1 s2->
-  BYTES.compare s1 s2
-
-let bytes_set = fun s n c->
-  BYTES.set s n c
-
-let bytes_iter = fun f s->
-  BYTES.iter f s
-
 IFDEF OCAML_V404 THEN
-let lowercase_ascii = BYTES.lowercase_ascii
+let lowercase_ascii = fun s -> Bytes.to_string (Bytes.lowercase_ascii s)
 
-let uppercase_ascii = BYTES.uppercase_ascii
+let uppercase_ascii = fun s -> Bytes.to_string (Bytes.uppercase_ascii s)
 
-let capitalize_ascii = BYTES.capitalize_ascii
+let capitalize_ascii = fun s -> Bytes.to_string (Bytes.capitalize_ascii s)
 
 ELSE
-let lowercase_ascii = BYTES.lowercase
+let lowercase_ascii = String.lowercase
 
-let uppercase_ascii = BYTES.uppercase
+let uppercase_ascii = String.uppercase
 
-let capitalize_ascii = BYTES.capitalize
+let capitalize_ascii = String.capitalize
 
 END

--- a/lib/common/ocaml/compatPL.mli
+++ b/lib/common/ocaml/compatPL.mli
@@ -22,21 +22,6 @@
  *
  *)
 
-val bytes_create : int -> string
-val bytes_contains : string -> char -> bool
-val bytes_length : string -> int
-val bytes_make : int -> char -> string
-val bytes_copy : string -> string
-val bytes_blit : string -> int -> string -> int -> int -> unit
-val bytes_sub : string -> int -> int -> string
-val bytes_index : string -> char -> int
-val bytes_concat : string -> string list -> string
-val bytes_index_from : string -> int -> char -> int
-val bytes_get : string -> int -> char
-val bytes_compare : string -> string -> int
-val bytes_set : string -> int -> char -> unit
-val bytes_iter : (char -> unit) -> string -> unit
-
 val lowercase_ascii : string -> string
 val uppercase_ascii : string -> string
 val capitalize_ascii : string -> string

--- a/lib/common/ocaml/debugPL.ml
+++ b/lib/common/ocaml/debugPL.ml
@@ -26,7 +26,7 @@ let level = ref (try Sys.getenv "PPRZ_DEBUG" with Not_found -> "")
 let log = ref stderr
 let call lev f =
   assert( (* assert permet au compilo de tout virer avec l'option -noassert *)
-    if (CompatPL.bytes_contains !level '*' || CompatPL.bytes_contains !level lev)
+    if (Bytes.contains !level '*' || Bytes.contains !level lev)
     then begin
       f !log;
       flush !log
@@ -36,11 +36,11 @@ let call lev f =
 let trace lev s = call lev (fun f -> Printf.fprintf f "%s\n" s)
 
 let xprint = fun s ->
-  let n = CompatPL.bytes_length s in
-  let a = CompatPL.bytes_make (3*n) ' ' in
+  let n = Bytes.length s in
+  let a = Bytes.make (3*n) ' ' in
   for i = 0 to n - 1 do
     let x = Printf.sprintf "%02x" (Char.code s.[i]) in
-    CompatPL.bytes_set a (3*i) x.[0];
-    CompatPL.bytes_set a (3*i+1) x.[1]
+    Bytes.set a (3*i) x.[0];
+    Bytes.set a (3*i+1) x.[1]
   done;
   a

--- a/lib/common/ocaml/pprz_transport.ml
+++ b/lib/common/ocaml/pprz_transport.ml
@@ -35,10 +35,10 @@ end
 
 module PprzTransportBase(SubType:TRANSPORT_TYPE) = struct
   let index_start = fun buf ->
-    CompatPL.bytes_index buf SubType.stx
+    Bytes.index buf SubType.stx
 
   let length = fun buf start ->
-    let len = CompatPL.bytes_length buf - start in
+    let len = Bytes.length buf - start in
     if len > SubType.offset_length then
       let l = Char.code buf.[start+SubType.offset_length] in
       DebugPL.call 'T' (fun f -> fprintf f "Pprz_transport len=%d\n" l);
@@ -48,7 +48,7 @@ module PprzTransportBase(SubType:TRANSPORT_TYPE) = struct
 
   let (+=) = fun r x -> r := (!r + x) land 0xff
   let compute_checksum = fun msg ->
-    let l = CompatPL.bytes_length msg in
+    let l = Bytes.length msg in
     let ck_a = ref 0  and ck_b = ref 0 in
     for i = 1 to l - 3 do
       ck_a += Char.code msg.[i];
@@ -57,30 +57,30 @@ module PprzTransportBase(SubType:TRANSPORT_TYPE) = struct
     !ck_a, !ck_b
 
   let checksum = fun msg ->
-    let l = CompatPL.bytes_length msg in
+    let l = Bytes.length msg in
     let ck_a, ck_b = compute_checksum msg in
     DebugPL.call 'T' (fun f -> fprintf f "Pprz_transport cs: %d %d | %d %d\n" ck_a (Char.code msg.[l-2]) ck_b (Char.code msg.[l-1]));
     ck_a = Char.code msg.[l-2] && ck_b = Char.code msg.[l-1]
 
   let payload = fun msg ->
-    let l = CompatPL.bytes_length msg in
+    let l = Bytes.length msg in
     assert(Char.code msg.[SubType.offset_length] = l);
     assert(l >= SubType.overhead_length);
-    Protocol.payload_of_string (CompatPL.bytes_sub msg SubType.offset_payload (l-SubType.overhead_length))
+    Protocol.payload_of_string (Bytes.sub msg SubType.offset_payload (l-SubType.overhead_length))
 
   let packet = fun payload ->
     let payload = Protocol.string_of_payload payload in
-    let n = CompatPL.bytes_length payload in
+    let n = Bytes.length payload in
     let msg_length = n + SubType.overhead_length in (** + stx, len, ck_a and ck_b *)
     if msg_length >= 256 then
       invalid_arg "Pprz_transport.Transport.packet";
-    let m = CompatPL.bytes_create msg_length in
-    CompatPL.bytes_blit payload 0 m SubType.offset_payload n;
-    CompatPL.bytes_set m 0 SubType.stx;
-    CompatPL.bytes_set m SubType.offset_length (Char.chr msg_length);
+    let m = Bytes.create msg_length in
+    Bytes.blit payload 0 m SubType.offset_payload n;
+    Bytes.set m 0 SubType.stx;
+    Bytes.set m SubType.offset_length (Char.chr msg_length);
     let (ck_a, ck_b) = compute_checksum m in
-    CompatPL.bytes_set m (msg_length-2) (Char.chr ck_a);
-    CompatPL.bytes_set m (msg_length-1) (Char.chr ck_b);
+    Bytes.set m (msg_length-2) (Char.chr ck_a);
+    Bytes.set m (msg_length-1) (Char.chr ck_b);
     m
 end
 

--- a/lib/common/ocaml/pprzlog_transport.ml
+++ b/lib/common/ocaml/pprzlog_transport.ml
@@ -39,10 +39,10 @@ module Transport = struct
   let offset_payload = 2
 
   let index_start = fun buf ->
-    CompatPL.bytes_index buf stx
+    Bytes.index buf stx
 
   let length = fun buf start ->
-    let len = CompatPL.bytes_length buf - start in
+    let len = Bytes.length buf - start in
     if len > offset_length then
       let l = Char.code buf.[start+offset_length] in
       DebugPL.call 'T' (fun f -> fprintf f "Pprzlog_transport len=%d\n" l);
@@ -52,7 +52,7 @@ module Transport = struct
 
   let (+=) = fun r x -> r := (!r + x) land 0xff
   let compute_checksum = fun msg ->
-    let l = CompatPL.bytes_length msg in
+    let l = Bytes.length msg in
     let ck_a = ref 0 in
     for i = 1 to l - 2 do
       ck_a += Char.code msg.[i]
@@ -60,34 +60,34 @@ module Transport = struct
     !ck_a
 
   let checksum = fun msg ->
-    let l = CompatPL.bytes_length msg in
+    let l = Bytes.length msg in
     let ck_a = compute_checksum msg in
     DebugPL.call 'T' (fun f -> fprintf f "Pprzlog_transport cs: %d %d\n" ck_a (Char.code msg.[l-1]));
     ck_a = Char.code msg.[l-1]
 
   let payload = fun msg ->
-    let l = CompatPL.bytes_length msg in
+    let l = Bytes.length msg in
     assert(Char.code msg.[offset_length] + 8 = l);
-    Protocol.payload_of_string (CompatPL.bytes_sub msg offset_payload (l-3))
+    Protocol.payload_of_string (Bytes.sub msg offset_payload (l-3))
 
   let packet = fun payload ->
     let payload = Protocol.string_of_payload payload in
-    let n = CompatPL.bytes_length payload in
+    let n = Bytes.length payload in
     let msg_length = n + 3 in (** + stx, len, ck_a *)
     if msg_length >= 256 then
       invalid_arg "Pprzlog_transport.Transport.packet";
-    let m = CompatPL.bytes_create msg_length in
-    CompatPL.bytes_blit payload 0 m offset_payload n;
-    CompatPL.bytes_set m 0 stx;
-    CompatPL.bytes_set m offset_length (Char.chr (msg_length - 8));
+    let m = Bytes.create msg_length in
+    Bytes.blit payload 0 m offset_payload n;
+    Bytes.set m 0 stx;
+    Bytes.set m offset_length (Char.chr (msg_length - 8));
     let ck_a = compute_checksum m in
-    CompatPL.bytes_set m (msg_length-1) (Char.chr ck_a);
+    Bytes.set m (msg_length-1) (Char.chr ck_a);
     m
 end
 
 let pprz_payload_of_payload = fun s ->
-  let n = CompatPL.bytes_length s in
-  Protocol.payload_of_string (CompatPL.bytes_sub s 5 (n - 5))
+  let n = Bytes.length s in
+  Protocol.payload_of_string (Bytes.sub s 5 (n - 5))
 
 let parse = fun p ->
   let s = Protocol.string_of_payload p in

--- a/lib/common/ocaml/protocol.ml
+++ b/lib/common/ocaml/protocol.ml
@@ -46,7 +46,7 @@ module Transport(Protocol:PROTOCOL) = struct
     DebugPL.call 'T' (fun f -> fprintf f "Transport.parse: %s\n" (DebugPL.xprint buf));
     (** ref required due to Not_enough exception raised by Protocol.length *)
     let start = ref 0
-    and n = CompatPL.bytes_length buf in
+    and n = Bytes.length buf in
     try
       (* Looks for the beginning of the frame. May raise Not_found exception *)
       start := Protocol.index_start buf;
@@ -63,7 +63,7 @@ module Transport(Protocol:PROTOCOL) = struct
         raise Not_enough;
 
       (* Extracts the complete frame *)
-      let msg = CompatPL.bytes_sub buf !start length in
+      let msg = Bytes.sub buf !start length in
 
       (* Checks sum *)
       if Protocol.checksum msg then begin
@@ -77,8 +77,8 @@ module Transport(Protocol:PROTOCOL) = struct
       end;
 
       (* Continues with the rest of the message *)
-      end_ + parse use (CompatPL.bytes_sub buf end_ (CompatPL.bytes_length buf - end_))
+      end_ + parse use (Bytes.sub buf end_ (Bytes.length buf - end_))
     with
-        Not_found -> CompatPL.bytes_length buf
+        Not_found -> Bytes.length buf
       | Not_enough -> !start
 end

--- a/lib/common/ocaml/xbee_transport.ml
+++ b/lib/common/ocaml/xbee_transport.ml
@@ -29,17 +29,17 @@ module Transport = struct
   let size_packet = 4
 
   let index_start = fun s ->
-    CompatPL.bytes_index s start_delimiter
+    Bytes.index s start_delimiter
 
   let length = fun s i ->
-    if CompatPL.bytes_length s < i+offset_length+2 then
+    if Bytes.length s < i+offset_length+2 then
       raise Protocol.Not_enough
     else
       (Char.code s.[i+offset_length] lsl 8) lor (Char.code s.[i+offset_length+1]) + size_packet
 
   let compute_checksum = fun s ->
     let cs = ref 0 in
-    for i = offset_payload to CompatPL.bytes_length s - 2 do
+    for i = offset_payload to Bytes.length s - 2 do
       cs := (!cs + Char.code s.[i]) land 0xff
     done;
     0xff - !cs
@@ -47,22 +47,22 @@ module Transport = struct
   let checksum = fun s ->
     let c = compute_checksum s in
     DebugPL.call 'x' (fun f -> Printf.fprintf f "XB.cs=%x\n" c);
-    c = Char.code s.[CompatPL.bytes_length s-1]
+    c = Char.code s.[Bytes.length s-1]
 
   let payload = fun s ->
-    Protocol.payload_of_string (CompatPL.bytes_sub s offset_payload (CompatPL.bytes_length s - size_packet))
+    Protocol.payload_of_string (Bytes.sub s offset_payload (Bytes.length s - size_packet))
 
   let packet = fun payload ->
     let payload = Protocol.string_of_payload payload in
-    let n = CompatPL.bytes_length payload in
+    let n = Bytes.length payload in
     let msg_length = n + size_packet in
-    let m = CompatPL.bytes_create msg_length in
-    CompatPL.bytes_blit payload 0 m offset_payload n;
-    CompatPL.bytes_set m 0 start_delimiter;
-    CompatPL.bytes_set m (offset_length) (Char.chr (n lsr 8));
-    CompatPL.bytes_set m (offset_length+1) (Char.chr (n land 0xff));
+    let m = Bytes.create msg_length in
+    Bytes.blit payload 0 m offset_payload n;
+    Bytes.set m 0 start_delimiter;
+    Bytes.set m (offset_length) (Char.chr (n lsr 8));
+    Bytes.set m (offset_length+1) (Char.chr (n land 0xff));
     let cs = compute_checksum m in
-    CompatPL.bytes_set m (msg_length-1) (Char.chr cs);
+    Bytes.set m (msg_length-1) (Char.chr cs);
     m
 end
 
@@ -104,7 +104,7 @@ let api_rx16_id = Char.chr 0x81
 
 let write_int64 = fun buf offset x ->
   for i = 0 to 7 do
-    CompatPL.bytes_set buf (offset+7-i) (Char.chr (Int64.to_int (Int64.shift_right x (8*i)) land 0xff))
+    Bytes.set buf (offset+7-i) (Char.chr (Int64.to_int (Int64.shift_right x (8*i)) land 0xff))
   done
 
 let read_int64 = fun buf offset ->
@@ -115,44 +115,44 @@ let read_int64 = fun buf offset ->
   !x
 
 let write_int16 = fun buf offset x ->
-  CompatPL.bytes_set buf offset (Char.chr (x lsr 8));
-  CompatPL.bytes_set buf (offset+1) (Char.chr (x land 0xff))
+  Bytes.set buf offset (Char.chr (x lsr 8));
+  Bytes.set buf (offset+1) (Char.chr (x land 0xff))
 
 let read_int16 = fun buf offset ->
   (Char.code buf.[offset] lsl 8) lor (Char.code buf.[offset+1])
 
 let api_tx64 = fun ?(frame_id = 0) dest data ->
   assert (frame_id >=0 && frame_id < 0x100);
-  let n = CompatPL.bytes_length data in
+  let n = Bytes.length data in
   assert (n <= 100);
   let optional868 = if !mode868 then 3 else 0 in
   let l = 1 + 1 + 8 + optional868 + 1 + n in
-  let s = CompatPL.bytes_create l in
-  CompatPL.bytes_set s 0 api_tx64_id;
-  CompatPL.bytes_set s 1 (Char.chr frame_id);
+  let s = Bytes.create l in
+  Bytes.set s 0 api_tx64_id;
+  Bytes.set s 1 (Char.chr frame_id);
   if !mode868 then begin
-    CompatPL.bytes_set s 10 (Char.chr 0xff);
-    CompatPL.bytes_set s 11 (Char.chr 0xfe);
-    CompatPL.bytes_set s 12 (Char.chr 0x0);
+    Bytes.set s 10 (Char.chr 0xff);
+    Bytes.set s 11 (Char.chr 0xfe);
+    Bytes.set s 12 (Char.chr 0x0);
   end;
   write_int64 s 2 dest;
-  CompatPL.bytes_set s (10+optional868) (Char.chr 0);
-  CompatPL.bytes_blit data 0 s (11+ optional868) n;
+  Bytes.set s (10+optional868) (Char.chr 0);
+  Bytes.blit data 0 s (11+ optional868) n;
   s
 
 let api_tx16 = fun ?(frame_id = 0) dest data ->
   check_not_in_868 "api_tx16";
   assert (frame_id >=0 && frame_id < 0x100);
-  let n = CompatPL.bytes_length data in
+  let n = Bytes.length data in
   assert (n <= 100);
   let l = 1 + 1 + 2 + 1 + n in
-  let s = CompatPL.bytes_create l in
-  CompatPL.bytes_set s 0 api_tx16_id;
-  CompatPL.bytes_set s 1 (Char.chr frame_id);
+  let s = Bytes.create l in
+  Bytes.set s 0 api_tx16_id;
+  Bytes.set s 1 (Char.chr frame_id);
   assert (dest >= 0 && dest < 0x10000);
   write_int16 s 2 dest;
-  CompatPL.bytes_set s 4 (Char.chr 0);
-  CompatPL.bytes_blit data 0 s 5 n;
+  Bytes.set s 4 (Char.chr 0);
+  Bytes.blit data 0 s 5 n;
   s
 
 
@@ -176,13 +176,13 @@ let at_exit = "ATCN\r"
 let at_api_enable = "ATAP1\r"
 
 let api_parse_frame = fun s ->
-  let n = CompatPL.bytes_length s in
+  let n = Bytes.length s in
   assert(n>0);
   match s.[0] with
       x when x = api_at_command_response_id ->
         assert(n >= 5);
-        AT_Command_Response (Char.code s.[1], CompatPL.bytes_sub s 2 2,
-                             Char.code s.[4], CompatPL.bytes_sub s 5 (n-5))
+        AT_Command_Response (Char.code s.[1], Bytes.sub s 2 2,
+                             Char.code s.[4], Bytes.sub s 5 (n-5))
     | x when not !mode868 && x = api_tx_status_id ->
       assert(n = 3);
       TX_Status (Char.code s.[1], Char.code s.[2])
@@ -194,13 +194,13 @@ let api_parse_frame = fun s ->
     | x when not !mode868 && x = api_rx64_id ->
       assert(n >= 11);
       RX_Packet_64 (read_int64 s 1, Char.code s.[9],
-                    Char.code s.[10], CompatPL.bytes_sub s 11 (n-11))
+                    Char.code s.[10], Bytes.sub s 11 (n-11))
     | x when !mode868 && x = api868_rx64_id ->
       let idx_data = 12 in
       assert(n >= idx_data);
       RX868_Packet (read_int64 s 1,
-                    Char.code s.[11], CompatPL.bytes_sub s idx_data (n-idx_data))
+                    Char.code s.[11], Bytes.sub s idx_data (n-idx_data))
     | x when not !mode868 && (x = api_rx16_id || x = api_tx16_id) ->
       (* tx16 here allows to receive simulated xbee messages *)
-      RX_Packet_16 (read_int16 s 1, Char.code s.[3], Char.code  s.[4], CompatPL.bytes_sub s 5 (n-5))
+      RX_Packet_16 (read_int16 s 1, Char.code s.[3], Char.code  s.[4], Bytes.sub s 5 (n-5))
     | x -> failwith (Printf.sprintf "Xbee.parse_frame: unknown frame id '%d'" (Char.code x))

--- a/lib/v1.0/ocaml/pprzLink.ml
+++ b/lib/v1.0/ocaml/pprzLink.ml
@@ -292,14 +292,14 @@ let xml_attrib = fun x a ->
 let xml_int_attrib = fun xml a ->
   let v = xml_attrib xml a in
   try
-    Pervasives.int_of_string v
+    int_of_string v
   with
       _ -> failwith (Printf.sprintf "Error: integer expected in '%s'" v)
 
 let xml_float_attrib = fun xml a ->
   let v = xml_attrib xml a in
   try
-    Pervasives.float_of_string v
+    float_of_string v
   with
       _ -> failwith (Printf.sprintf "Error: float expected in '%s'" v)
 
@@ -318,7 +318,7 @@ let xml_child xml ?select c =
   in
   let children = Xml.children xml in
   (* Let's try with a numeric index *)
-  try (Array.of_list children).(Pervasives.int_of_string c) with
+  try (Array.of_list children).(int_of_string c) with
     Failure _ -> (* Bad luck. Go through the children *)
       find children
 

--- a/lib/v2.0/ocaml/pprzLink.ml
+++ b/lib/v2.0/ocaml/pprzLink.ml
@@ -119,12 +119,12 @@ let types = [
 ]
 
 let is_array_type = fun s ->
-  let n = CompatPL.bytes_length s in
-  n >= 2 && CompatPL.bytes_sub s (n-2) 2 = "[]"
+  let n = Bytes.length s in
+  n >= 2 && Bytes.sub s (n-2) 2 = "[]"
 
 let type_of_array_type = fun s ->
-  let n = CompatPL.bytes_length s in
-  CompatPL.bytes_sub s 0 (n-2)
+  let n = Bytes.length s in
+  Bytes.sub s 0 (n-2)
 
 let is_fixed_array_type = fun s ->
   let type_parts = Str.full_split (Str.regexp "[][]") s in
@@ -184,13 +184,13 @@ let rec string_of_value = function
   | Float x -> string_of_float x
   | Int32 x -> Int32.to_string x
   | Int64 x -> Int64.to_string x
-  | Char c -> CompatPL.bytes_make 1 c
+  | Char c -> Bytes.make 1 c
   | String s -> s
   | Array a ->
       let l = (Array.to_list (Array.map string_of_value a)) in
       match a.(0) with
-      | Char _ -> "\""^(CompatPL.bytes_concat "" l)^"\""
-      | _ -> CompatPL.bytes_concat separator l
+      | Char _ -> "\""^(Bytes.concat "" l)^"\""
+      | _ -> Bytes.concat separator l
 
 
 let rec formatted_string_of_value = fun format v ->
@@ -205,8 +205,8 @@ let rec formatted_string_of_value = fun format v ->
     | Array a ->
         let l = (Array.to_list (Array.map (formatted_string_of_value format) a)) in
         match a.(0) with
-        | Char _ -> "\""^(CompatPL.bytes_concat "" l)^"\""
-        | _ -> CompatPL.bytes_concat separator l
+        | Char _ -> "\""^(Bytes.concat "" l)^"\""
+        | _ -> Bytes.concat separator l
 
 
 let sizeof = fun f ->
@@ -339,7 +339,7 @@ let field_of_xml = fun xml ->
     { _type = t; fformat = f; alt_unit_coef = auc; enum=values })
 
 let string_of_values = fun vs ->
-  CompatPL.bytes_concat " " (List.map (fun (a,v) -> sprintf "%s=%s" a (string_of_value v)) vs)
+  Bytes.concat " " (List.map (fun (a,v) -> sprintf "%s=%s" a (string_of_value v)) vs)
 
 let assoc = fun a vs ->
   try List.assoc (CompatPL.lowercase_ascii a) vs with Not_found ->
@@ -452,7 +452,7 @@ let rec value_of_bin = fun buffer index _type ->
          (fun i -> fst (value_of_bin buffer (index+0+i*s) type_of_elt))), size)
     | Scalar "string" ->
       let n = Char.code buffer.[index] in
-      (String (CompatPL.bytes_sub buffer (index+1) n), (1+n))
+      (String (Bytes.sub buffer (index+1) n), (1+n))
     | _ -> failwith "value_of_bin"
 
 let value_field = fun buf index field ->
@@ -466,7 +466,7 @@ let rec sprint_value = fun buf i _type v ->
       Scalar "uint8", Int x ->
         if x < 0 || x > 0xff then
           failwith (sprintf "Value too large to fit in a uint8: %d" x);
-        CompatPL.bytes_set buf i (Char.chr x); sizeof _type
+        Bytes.set buf i (Char.chr x); sizeof _type
     | Scalar "int8", Int x ->
         if x < -0x7f || x > 0x7f then
           failwith (sprintf "Value too large to fit in a int8: %d" x);
@@ -478,26 +478,26 @@ let rec sprint_value = fun buf i _type v ->
     | Scalar "int16", Int x -> sprint_int16 buf i x; sizeof _type
     | Scalar ("int32" | "uint32"), Int value ->
         assert (_type <> Scalar "uint32" || value >= 0);
-        CompatPL.bytes_set buf (i+3) (byte (value asr 24));
-        CompatPL.bytes_set buf (i+2) (byte (value lsr 16));
-        CompatPL.bytes_set buf (i+1) (byte (value lsr 8));
-        CompatPL.bytes_set buf (i+0) (byte value);
+        Bytes.set buf (i+3) (byte (value asr 24));
+        Bytes.set buf (i+2) (byte (value lsr 16));
+        Bytes.set buf (i+1) (byte (value lsr 8));
+        Bytes.set buf (i+0) (byte value);
         sizeof _type
     | Scalar ("int64" | "uint64"), Int value ->
         assert (_type <> Scalar "uint64" || value >= 0);
-        CompatPL.bytes_set buf (i+7) (byte (value asr 56));
-        CompatPL.bytes_set buf (i+6) (byte (value lsr 48));
-        CompatPL.bytes_set buf (i+5) (byte (value lsr 40));
-        CompatPL.bytes_set buf (i+4) (byte (value lsr 32));
-        CompatPL.bytes_set buf (i+3) (byte (value lsr 24));
-        CompatPL.bytes_set buf (i+2) (byte (value lsr 16));
-        CompatPL.bytes_set buf (i+1) (byte (value lsr 8));
-        CompatPL.bytes_set buf (i+0) (byte value);
+        Bytes.set buf (i+7) (byte (value asr 56));
+        Bytes.set buf (i+6) (byte (value lsr 48));
+        Bytes.set buf (i+5) (byte (value lsr 40));
+        Bytes.set buf (i+4) (byte (value lsr 32));
+        Bytes.set buf (i+3) (byte (value lsr 24));
+        Bytes.set buf (i+2) (byte (value lsr 16));
+        Bytes.set buf (i+1) (byte (value lsr 8));
+        Bytes.set buf (i+0) (byte value);
         sizeof _type
     | Scalar "uint16", Int value ->
         assert (value >= 0);
-        CompatPL.bytes_set buf (i+1) (byte (value lsr 8));
-        CompatPL.bytes_set buf (i+0) (byte value);
+        Bytes.set buf (i+1) (byte (value lsr 8));
+        Bytes.set buf (i+0) (byte value);
         sizeof _type
     | ArrayType t, Array values ->
         (** Put the size first, then the values *)
@@ -520,7 +520,7 @@ let rec sprint_value = fun buf i _type v ->
         (* add padding 0 at the end if needed *)
         if l > n then
           for j = n*s to l*s-1 do
-            CompatPL.bytes_set buf (i+j) (Char.chr 0)
+            Bytes.set buf (i+j) (Char.chr 0)
         done;
         0 + l * s
     | ArrayType "char", String value ->
@@ -530,16 +530,16 @@ let rec sprint_value = fun buf i _type v ->
         sprint_value buf i (FixedArrayType ("char",l))
           (Array (Array.init (String.length value) (fun i -> Char (String.get value i))))
     | Scalar "string", String s ->
-        let n = CompatPL.bytes_length s in
+        let n = Bytes.length s in
         assert (n < 256);
         (** Put the length first, then the bytes *)
-        CompatPL.bytes_set buf i (Char.chr n);
-        if (i + n >= CompatPL.bytes_length buf) then
+        Bytes.set buf i (Char.chr n);
+        if (i + n >= Bytes.length buf) then
           failwith "Error in sprint_value: message too long";
-          CompatPL.bytes_blit s 0 buf (i+1) n;
+          Bytes.blit s 0 buf (i+1) n;
           1 + n
     | Scalar "char", Char c ->
-        CompatPL.bytes_set buf i c; sizeof _type
+        Bytes.set buf i c; sizeof _type
     | (Scalar x|ArrayType x), v -> failwith (sprintf "PprzLink.sprint_value (%s):%s,%s" x (string_of_value v) (string_type_of_value v))
     | FixedArrayType (x,l), v -> failwith (sprintf "PprzLink.sprint_value (%s[%d]:%s,%s)" x l (string_of_value v) (string_type_of_value v))
 
@@ -549,13 +549,13 @@ let hex_of_int_array = function
 Array array ->
   let n = Array.length array in
       (* One integer -> 2 chars *)
-  let s = CompatPL.bytes_create (2*n) in
+  let s = Bytes.create (2*n) in
   Array.iteri
     (fun i dec ->
       let x = int_of_value array.(i) in
       assert (0 <= x && x <= 0xff);
       let hex = sprintf "%02x" x in
-      CompatPL.bytes_blit hex 0 s (2*i) 2)
+      Bytes.blit hex 0 s (2*i) 2)
     array;
   s
   | value ->
@@ -657,7 +657,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
       let rec loop = fun index fields ->
         match fields with
             [] ->
-              if index = CompatPL.bytes_length buffer then
+              if index = Bytes.length buffer then
                 []
               else
                 failwith (sprintf "PprzLink.values_of_payload, too many bytes in message %s: %s" message.name (DebugPL.xprint buffer))
@@ -674,13 +674,13 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
     let message = message_of_id id in
 
     (** The actual length is computed from the values *)
-    let p = CompatPL.bytes_make max_length '#' in
+    let p = Bytes.make max_length '#' in
 
-    CompatPL.bytes_set p offset_sender_id (Char.chr sender_id);
-    CompatPL.bytes_set p offset_receiver_id (Char.chr 0); (* for now, broadcast id *)
+    Bytes.set p offset_sender_id (Char.chr sender_id);
+    Bytes.set p offset_receiver_id (Char.chr 0); (* for now, broadcast id *)
     let id_of_class = match class_id with None -> 0 | Some id -> id in (* if class id is not defined (e.g. ground class) it means that this function should not be called either *)
-    CompatPL.bytes_set p offset_class_id (Char.chr id_of_class); (* for now, component id is set to 0 *)
-    CompatPL.bytes_set p offset_msg_id (Char.chr id);
+    Bytes.set p offset_class_id (Char.chr id_of_class); (* for now, component id is set to 0 *)
+    Bytes.set p offset_msg_id (Char.chr id);
     let i = ref offset_fields in
     List.iter
       (fun (field_name, field) ->
@@ -693,7 +693,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
       message.fields;
 
     (** Cut to the actual length *)
-    let p = CompatPL.bytes_sub p 0 !i in
+    let p = Bytes.sub p 0 !i in
     Protocol.payload_of_string p
 
 
@@ -732,7 +732,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
         then invalid_arg (sprintf "PprzLink.string_of_message: unknown field '%s' in message '%s'" k msg.name))
       values;
 
-    CompatPL.bytes_concat sep
+    Bytes.concat sep
       (msg.name::
          List.map
      (fun (field_name, field) ->
@@ -751,7 +751,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
           None -> ""
         | Some x -> sprintf "%f " x in
     let msg = sprintf "%s%s %s" timestamp_string sender s in
-    let n = CompatPL.bytes_length msg in
+    let n = Bytes.length msg in
     if n > 10000 then (** prevent really long Ivy message, should not happen with normal usage *)
       fprintf stderr "Discarding long ivy message %s (%d bytes)\n%!" msg_name n
     else
@@ -759,15 +759,15 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
         None -> Ivy.send msg
       | Some the_link_id -> begin
         let index = ref 0 in
-        let modified_msg = CompatPL.bytes_copy msg in
+        let modified_msg = Bytes.copy msg in
         let func = fun c ->
           match c with
             ' ' -> begin
-            CompatPL.bytes_set modified_msg !index ';';
+            Bytes.set modified_msg !index ';';
             index := !index + 1
             end
           | x -> index := !index + 1; in
-        CompatPL.bytes_iter func modified_msg;
+        Bytes.iter func modified_msg;
         Ivy.send (Printf.sprintf "redlink TELEMETRY_MESSAGE %s %i %s" sender the_link_id modified_msg);
       end
 

--- a/lib/v2.0/ocaml/pprzLink.ml
+++ b/lib/v2.0/ocaml/pprzLink.ml
@@ -295,14 +295,14 @@ let xml_attrib = fun x a ->
 let xml_int_attrib = fun xml a ->
   let v = xml_attrib xml a in
   try
-    Pervasives.int_of_string v
+    int_of_string v
   with
       _ -> failwith (Printf.sprintf "Error: integer expected in '%s'" v)
 
 let xml_float_attrib = fun xml a ->
   let v = xml_attrib xml a in
   try
-    Pervasives.float_of_string v
+    float_of_string v
   with
       _ -> failwith (Printf.sprintf "Error: float expected in '%s'" v)
 
@@ -321,7 +321,7 @@ let xml_child xml ?select c =
   in
   let children = Xml.children xml in
   (* Let's try with a numeric index *)
-  try (Array.of_list children).(Pervasives.int_of_string c) with
+  try (Array.of_list children).(int_of_string c) with
     Failure _ -> (* Bad luck. Go through the children *)
       find children
 


### PR DESCRIPTION
Drop support of ocaml < 4.02
We keep compatPL for functions that need ocaml 4.03 until end of life of Ubuntu Xenial 16.04
This is required to compile with 20.04