### PR TITLE
[fix] clean usage of string and bytes modules

### DIFF
--- a/lib/common/ocaml/Makefile
+++ b/lib/common/ocaml/Makefile
@@ -42,22 +42,15 @@ CAMLP4_DEFS ?=
 OCAML_VERSION := $(shell ocamlc -version)
 OCAML_MAJOR := $(shell echo $(OCAML_VERSION) | cut -f1 -d.)
 OCAMLC_MINOR := $(shell echo $(OCAML_VERSION) | cut -f2 -d.)
-ifeq ($(shell test $(OCAML_MAJOR) -lt 4; echo $$?),0)
-# need to use an old buggy ocaml(build) version: build-dir MUST be relative
-BUILDDIR ?= ../../../build/ocaml/pprzlink
-else
-# using a recent ocaml(build) version without THAT particular bug,
+# using a recent ocaml(build) version >= 4,
 # but build-dir MUST NOT contain ..
 # so use some magic here to get a normalized absolute path if PPRZLINK_DIR is not set
 PPRZLINK_DIR ?= $(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../../..)
 BUILDDIR ?= $(PPRZLINK_DIR)/build/ocaml/pprzlink
 
 ifeq ($(shell test $(OCAMLC_MINOR) -ge 2; echo $$?),0)
-# the Bytes module is available since OCaml 4.02.0
-CAMLP4_DEFS += -DHAS_BYTES_MODULE
 ifeq ($(shell test $(OCAMLC_MINOR) -ge 4; echo $$?),0)
 CAMLP4_DEFS += -DOCAML_V404
-endif
 endif
 endif
 
@@ -70,6 +63,8 @@ INSTALL_FLAGS += -destdir $(DESTDIR)
 endif
 
 PP_OPTS = -pp "camlp4o pa_macro.cmo $(CAMLP4_DEFS)"
+# enforce checking a clear type checking between bytes and string
+C_OPTS = -cflags -safe-string
 INSTALL_FILES = $(shell ls $(BUILDDIR)/*.so $(BUILDDIR)/*.a $(BUILDDIR)/*.mli $(BUILDDIR)/*.cm* $(BUILDDIR)/common/*.mli $(BUILDDIR)/common/*.cm*)
 
 
@@ -78,20 +73,20 @@ all: byte native
 byte: _tags META
 	@echo Build bytecode lib
 	$(Q)test -d $(BUILDDIR) || mkdir -p $(BUILDDIR)
-	$(Q)$(OCAMLBUILD) $(QUIET) $(PP_OPTS) -build-dir $(BUILDDIR) -I common lib-pprzlink.cma
+	$(Q)$(OCAMLBUILD) $(QUIET) $(PP_OPTS) $(C_OPTS) -build-dir $(BUILDDIR) -I common lib-pprzlink.cma
 	$(Q)cp META $(BUILDDIR)
 
 # byte with statically linked libs
 static: _tags META
 	@echo Build bytecode lib with static linking
 	$(Q)test -d $(BUILDDIR) || mkdir -p $(BUILDDIR)
-	$(Q)$(OCAMLBUILD) $(QUIET) -build-dir $(BUILDDIR) -tag static -I common lib-pprzlink.cma
+	$(Q)$(OCAMLBUILD) $(QUIET) $(PP_OPTS) $(C_OPTS) -build-dir $(BUILDDIR) -tag static -I common lib-pprzlink.cma
 	$(Q)cp META $(BUILDDIR)
 
 native: _tags META
 	@echo Build native lib
 	$(Q)test -d $(BUILDDIR) || mkdir -p $(BUILDDIR)
-	$(Q)$(OCAMLBUILD) $(QUIET) $(PP_OPTS) -build-dir $(BUILDDIR) -I common lib-pprzlink.cmxa
+	$(Q)$(OCAMLBUILD) $(QUIET) $(PP_OPTS) $(C_OPTS) -build-dir $(BUILDDIR) -I common lib-pprzlink.cmxa
 	$(Q)cp META $(BUILDDIR)
 
 install: clean_lib byte native META

--- a/lib/common/ocaml/compatPL.ml
+++ b/lib/common/ocaml/compatPL.ml
@@ -23,11 +23,11 @@
  *)
 
 IFDEF OCAML_V404 THEN
-let lowercase_ascii = fun s -> Bytes.to_string (Bytes.lowercase_ascii s)
+let lowercase_ascii = String.lowercase_ascii
 
-let uppercase_ascii = fun s -> Bytes.to_string (Bytes.uppercase_ascii s)
+let uppercase_ascii = String.uppercase_ascii
 
-let capitalize_ascii = fun s -> Bytes.to_string (Bytes.capitalize_ascii s)
+let capitalize_ascii = String.capitalize_ascii
 
 ELSE
 let lowercase_ascii = String.lowercase

--- a/lib/common/ocaml/debugPL.ml
+++ b/lib/common/ocaml/debugPL.ml
@@ -26,7 +26,7 @@ let level = ref (try Sys.getenv "PPRZ_DEBUG" with Not_found -> "")
 let log = ref stderr
 let call lev f =
   assert( (* assert permet au compilo de tout virer avec l'option -noassert *)
-    if (Bytes.contains !level '*' || Bytes.contains !level lev)
+    if (String.contains !level '*' || String.contains !level lev)
     then begin
       f !log;
       flush !log
@@ -36,11 +36,11 @@ let call lev f =
 let trace lev s = call lev (fun f -> Printf.fprintf f "%s\n" s)
 
 let xprint = fun s ->
-  let n = Bytes.length s in
+  let n = String.length s in
   let a = Bytes.make (3*n) ' ' in
   for i = 0 to n - 1 do
     let x = Printf.sprintf "%02x" (Char.code s.[i]) in
     Bytes.set a (3*i) x.[0];
     Bytes.set a (3*i+1) x.[1]
   done;
-  a
+  Bytes.to_string a

--- a/lib/common/ocaml/pprz_transport.ml
+++ b/lib/common/ocaml/pprz_transport.ml
@@ -35,10 +35,10 @@ end
 
 module PprzTransportBase(SubType:TRANSPORT_TYPE) = struct
   let index_start = fun buf ->
-    Bytes.index buf SubType.stx
+    String.index buf SubType.stx
 
   let length = fun buf start ->
-    let len = Bytes.length buf - start in
+    let len = String.length buf - start in
     if len > SubType.offset_length then
       let l = Char.code buf.[start+SubType.offset_length] in
       DebugPL.call 'T' (fun f -> fprintf f "Pprz_transport len=%d\n" l);
@@ -48,7 +48,7 @@ module PprzTransportBase(SubType:TRANSPORT_TYPE) = struct
 
   let (+=) = fun r x -> r := (!r + x) land 0xff
   let compute_checksum = fun msg ->
-    let l = Bytes.length msg in
+    let l = String.length msg in
     let ck_a = ref 0  and ck_b = ref 0 in
     for i = 1 to l - 3 do
       ck_a += Char.code msg.[i];
@@ -57,19 +57,19 @@ module PprzTransportBase(SubType:TRANSPORT_TYPE) = struct
     !ck_a, !ck_b
 
   let checksum = fun msg ->
-    let l = Bytes.length msg in
+    let l = String.length msg in
     let ck_a, ck_b = compute_checksum msg in
     DebugPL.call 'T' (fun f -> fprintf f "Pprz_transport cs: %d %d | %d %d\n" ck_a (Char.code msg.[l-2]) ck_b (Char.code msg.[l-1]));
     ck_a = Char.code msg.[l-2] && ck_b = Char.code msg.[l-1]
 
   let payload = fun msg ->
-    let l = Bytes.length msg in
+    let l = String.length msg in
     assert(Char.code msg.[SubType.offset_length] = l);
     assert(l >= SubType.overhead_length);
-    Protocol.payload_of_string (Bytes.sub msg SubType.offset_payload (l-SubType.overhead_length))
+    Protocol.payload_of_string (String.sub msg SubType.offset_payload (l-SubType.overhead_length))
 
   let packet = fun payload ->
-    let payload = Protocol.string_of_payload payload in
+    let payload = Protocol.bytes_of_payload payload in
     let n = Bytes.length payload in
     let msg_length = n + SubType.overhead_length in (** + stx, len, ck_a and ck_b *)
     if msg_length >= 256 then
@@ -78,10 +78,10 @@ module PprzTransportBase(SubType:TRANSPORT_TYPE) = struct
     Bytes.blit payload 0 m SubType.offset_payload n;
     Bytes.set m 0 SubType.stx;
     Bytes.set m SubType.offset_length (Char.chr msg_length);
-    let (ck_a, ck_b) = compute_checksum m in
+    let (ck_a, ck_b) = compute_checksum (Bytes.to_string m) in
     Bytes.set m (msg_length-2) (Char.chr ck_a);
     Bytes.set m (msg_length-1) (Char.chr ck_b);
-    m
+    Bytes.to_string m
 end
 
 module PprzTypeStandard = struct

--- a/lib/common/ocaml/pprzlog_transport.ml
+++ b/lib/common/ocaml/pprzlog_transport.ml
@@ -39,10 +39,10 @@ module Transport = struct
   let offset_payload = 2
 
   let index_start = fun buf ->
-    Bytes.index buf stx
+    String.index buf stx
 
   let length = fun buf start ->
-    let len = Bytes.length buf - start in
+    let len = String.length buf - start in
     if len > offset_length then
       let l = Char.code buf.[start+offset_length] in
       DebugPL.call 'T' (fun f -> fprintf f "Pprzlog_transport len=%d\n" l);
@@ -52,7 +52,7 @@ module Transport = struct
 
   let (+=) = fun r x -> r := (!r + x) land 0xff
   let compute_checksum = fun msg ->
-    let l = Bytes.length msg in
+    let l = String.length msg in
     let ck_a = ref 0 in
     for i = 1 to l - 2 do
       ck_a += Char.code msg.[i]
@@ -60,18 +60,18 @@ module Transport = struct
     !ck_a
 
   let checksum = fun msg ->
-    let l = Bytes.length msg in
+    let l = String.length msg in
     let ck_a = compute_checksum msg in
     DebugPL.call 'T' (fun f -> fprintf f "Pprzlog_transport cs: %d %d\n" ck_a (Char.code msg.[l-1]));
     ck_a = Char.code msg.[l-1]
 
   let payload = fun msg ->
-    let l = Bytes.length msg in
+    let l = String.length msg in
     assert(Char.code msg.[offset_length] + 8 = l);
-    Protocol.payload_of_string (Bytes.sub msg offset_payload (l-3))
+    Protocol.payload_of_string (String.sub msg offset_payload (l-3))
 
   let packet = fun payload ->
-    let payload = Protocol.string_of_payload payload in
+    let payload = Protocol.bytes_of_payload payload in
     let n = Bytes.length payload in
     let msg_length = n + 3 in (** + stx, len, ck_a *)
     if msg_length >= 256 then
@@ -80,21 +80,22 @@ module Transport = struct
     Bytes.blit payload 0 m offset_payload n;
     Bytes.set m 0 stx;
     Bytes.set m offset_length (Char.chr (msg_length - 8));
-    let ck_a = compute_checksum m in
+    let ck_a = compute_checksum (Bytes.to_string m) in
     Bytes.set m (msg_length-1) (Char.chr ck_a);
-    m
+    Bytes.to_string m
 end
 
 let pprz_payload_of_payload = fun s ->
-  let n = Bytes.length s in
-  Protocol.payload_of_string (Bytes.sub s 5 (n - 5))
+  let n = String.length s in
+  Protocol.payload_of_string (String.sub s 5 (n - 5))
 
 let parse = fun p ->
   let s = Protocol.string_of_payload p in
   let source = Char.code s.[0]
-  and timestamp = PprzLink.int32_of_bytes s 1 in
+  and timestamp = PprzLink.int32_of_bytes (Bytes.of_string s) 1 in
   {
     source = source;
     timestamp = timestamp;
     pprz_data = pprz_payload_of_payload s
   }
+

--- a/lib/common/ocaml/protocol.ml
+++ b/lib/common/ocaml/protocol.ml
@@ -28,6 +28,8 @@ type payload = string
 
 let string_of_payload = fun x -> x
 let payload_of_string = fun x -> x
+let bytes_of_payload = fun x -> Bytes.of_string x
+let payload_of_bytes = fun x -> Bytes.to_string x
 
 exception Not_enough
 
@@ -46,7 +48,7 @@ module Transport(Protocol:PROTOCOL) = struct
     DebugPL.call 'T' (fun f -> fprintf f "Transport.parse: %s\n" (DebugPL.xprint buf));
     (** ref required due to Not_enough exception raised by Protocol.length *)
     let start = ref 0
-    and n = Bytes.length buf in
+    and n = String.length buf in
     try
       (* Looks for the beginning of the frame. May raise Not_found exception *)
       start := Protocol.index_start buf;
@@ -63,7 +65,7 @@ module Transport(Protocol:PROTOCOL) = struct
         raise Not_enough;
 
       (* Extracts the complete frame *)
-      let msg = Bytes.sub buf !start length in
+      let msg = String.sub buf !start length in
 
       (* Checks sum *)
       if Protocol.checksum msg then begin
@@ -77,8 +79,8 @@ module Transport(Protocol:PROTOCOL) = struct
       end;
 
       (* Continues with the rest of the message *)
-      end_ + parse use (Bytes.sub buf end_ (Bytes.length buf - end_))
+      end_ + parse use (String.sub buf end_ (String.length buf - end_))
     with
-        Not_found -> Bytes.length buf
+        Not_found -> String.length buf
       | Not_enough -> !start
 end

--- a/lib/common/ocaml/protocol.mli
+++ b/lib/common/ocaml/protocol.mli
@@ -26,6 +26,8 @@ type payload
 
 val string_of_payload : payload -> string
 val payload_of_string : string -> payload
+val bytes_of_payload : payload -> bytes
+val payload_of_bytes : bytes -> payload
 
 exception Not_enough
 

--- a/lib/common/ocaml/xbee_transport.mli
+++ b/lib/common/ocaml/xbee_transport.mli
@@ -58,7 +58,7 @@ val api_parse_frame : frame_data -> frame
 val mode868 : bool ref
 
 (** Building API frames data *)
-val api_tx64 : ?frame_id:int -> int64 -> string -> frame_data
-val api_tx16 : ?frame_id:int -> int -> string -> frame_data
+val api_tx64 : ?frame_id:int -> int64 -> bytes -> frame_data
+val api_tx16 : ?frame_id:int -> int -> bytes -> frame_data
 
 

--- a/lib/v1.0/ocaml/pprzLink.ml
+++ b/lib/v1.0/ocaml/pprzLink.ml
@@ -2,7 +2,7 @@
  * PPRZLINK message protocol handling
  *
  * Copyright (C) 2003 Pascal Brisset, Antoine Drouin
- * Copyright (C) 2015 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Copyright (C) 2015-2020 Gautier Hattenberger <gautier.hattenberger@enac.fr>
  *
  * This file is part of paparazzi.
  *
@@ -86,19 +86,19 @@ let lazy_messages_xml = lazy (Xml.parse_file messages_file)
 let messages_xml = fun () -> Lazy.force lazy_messages_xml
 let units_file = pprzlink_dir // "units.xml"
 
-external float_of_bytes : string -> int -> float = "c_float_of_indexed_bytes"
-external double_of_bytes : string -> int -> float = "c_double_of_indexed_bytes"
-external int8_of_bytes : string -> int -> int = "c_int8_of_indexed_bytes"
-external int16_of_bytes : string -> int -> int = "c_int16_of_indexed_bytes"
-external int32_of_bytes : string -> int -> int32 = "c_int32_of_indexed_bytes"
-external uint32_of_bytes : string -> int -> int64 = "c_uint32_of_indexed_bytes"
-external int64_of_bytes : string -> int -> int64 = "c_int64_of_indexed_bytes"
-external sprint_float : string -> int -> float -> unit = "c_sprint_float"
-external sprint_double : string -> int -> float -> unit = "c_sprint_double"
-external sprint_int64 : string -> int -> int64 -> unit = "c_sprint_int64"
-external sprint_int32 : string -> int -> int32 -> unit = "c_sprint_int32"
-external sprint_int16 : string -> int -> int -> unit = "c_sprint_int16"
-external sprint_int8 : string -> int -> int -> unit = "c_sprint_int8"
+external float_of_bytes : bytes -> int -> float = "c_float_of_indexed_bytes"
+external double_of_bytes : bytes -> int -> float = "c_double_of_indexed_bytes"
+external int8_of_bytes : bytes -> int -> int = "c_int8_of_indexed_bytes"
+external int16_of_bytes : bytes -> int -> int = "c_int16_of_indexed_bytes"
+external int32_of_bytes : bytes -> int -> int32 = "c_int32_of_indexed_bytes"
+external uint32_of_bytes : bytes -> int -> int64 = "c_uint32_of_indexed_bytes"
+external int64_of_bytes : bytes -> int -> int64 = "c_int64_of_indexed_bytes"
+external sprint_float : bytes -> int -> float -> unit = "c_sprint_float"
+external sprint_double : bytes -> int -> float -> unit = "c_sprint_double"
+external sprint_int64 : bytes -> int -> int64 -> unit = "c_sprint_int64"
+external sprint_int32 : bytes -> int -> int32 -> unit = "c_sprint_int32"
+external sprint_int16 : bytes -> int -> int -> unit = "c_sprint_int16"
+external sprint_int8 : bytes -> int -> int -> unit = "c_sprint_int8"
 
 let types = [
   ("uint8",  { format = "%u"; glib_type = "guint8"; inttype = "uint8_t";  size = 1; value=Int 42 });
@@ -116,12 +116,12 @@ let types = [
 ]
 
 let is_array_type = fun s ->
-  let n = Bytes.length s in
-  n >= 2 && Bytes.sub s (n-2) 2 = "[]"
+  let n = String.length s in
+  n >= 2 && String.sub s (n-2) 2 = "[]"
 
 let type_of_array_type = fun s ->
-  let n = Bytes.length s in
-  Bytes.sub s 0 (n-2)
+  let n = String.length s in
+  String.sub s 0 (n-2)
 
 let is_fixed_array_type = fun s ->
   let type_parts = Str.full_split (Str.regexp "[][]") s in
@@ -181,13 +181,13 @@ let rec string_of_value = function
   | Float x -> string_of_float x
   | Int32 x -> Int32.to_string x
   | Int64 x -> Int64.to_string x
-  | Char c -> Bytes.make 1 c
+  | Char c -> String.make 1 c
   | String s -> s
   | Array a ->
       let l = (Array.to_list (Array.map string_of_value a)) in
       match a.(0) with
-      | Char _ -> "\""^(Bytes.concat "" l)^"\""
-      | _ -> Bytes.concat separator l
+      | Char _ -> "\""^(String.concat "" l)^"\""
+      | _ -> String.concat separator l
 
 
 let rec formatted_string_of_value = fun format v ->
@@ -202,8 +202,8 @@ let rec formatted_string_of_value = fun format v ->
     | Array a ->
         let l = (Array.to_list (Array.map (formatted_string_of_value format) a)) in
         match a.(0) with
-        | Char _ -> "\""^(Bytes.concat "" l)^"\""
-        | _ -> Bytes.concat separator l
+        | Char _ -> "\""^(String.concat "" l)^"\""
+        | _ -> String.concat separator l
 
 
 let sizeof = fun f ->
@@ -336,7 +336,7 @@ let field_of_xml = fun xml ->
     { _type = t; fformat = f; alt_unit_coef = auc; enum=values })
 
 let string_of_values = fun vs ->
-  Bytes.concat " " (List.map (fun (a,v) -> sprintf "%s=%s" a (string_of_value v)) vs)
+  String.concat " " (List.map (fun (a,v) -> sprintf "%s=%s" a (string_of_value v)) vs)
 
 let assoc = fun a vs ->
   try List.assoc (CompatPL.lowercase_ascii a) vs with Not_found ->
@@ -420,10 +420,10 @@ let parse_class = fun xml_class ->
 (** Returns a value and its length *)
 let rec value_of_bin = fun buffer index _type ->
   match _type with
-      Scalar "uint8" -> Int (Char.code buffer.[index]), sizeof _type
-    | Scalar "char" -> Char (buffer.[index]), sizeof _type
+      Scalar "uint8" -> Int (Char.code (Bytes.get buffer index)), sizeof _type
+    | Scalar "char" -> Char (Bytes.get buffer index), sizeof _type
     | Scalar "int8" -> Int (int8_of_bytes buffer index), sizeof _type
-    | Scalar "uint16" -> Int (Char.code buffer.[index+1] lsl 8 + Char.code buffer.[index]), sizeof _type
+    | Scalar "uint16" -> Int (Char.code (Bytes.get buffer (index+1)) lsl 8 + Char.code (Bytes.get buffer index)), sizeof _type
     | Scalar "int16" -> Int (int16_of_bytes buffer index), sizeof _type
     | Scalar "float" -> Float (float_of_bytes buffer index), sizeof _type
     | Scalar "double" -> Float (double_of_bytes buffer index), sizeof _type
@@ -432,7 +432,7 @@ let rec value_of_bin = fun buffer index _type ->
     | Scalar ("int64"  | "uint64") -> Int64 (int64_of_bytes buffer index), sizeof _type
     | ArrayType t ->
       (** First get the number of values *)
-      let n = int8_of_bytes buffer index in
+      let n = Char.code (Bytes.get buffer index) in
       let type_of_elt = Scalar t in
       let s = sizeof type_of_elt in
       let size = 1 + n * s in
@@ -447,8 +447,8 @@ let rec value_of_bin = fun buffer index _type ->
       (Array (Array.init n
          (fun i -> fst (value_of_bin buffer (index+0+i*s) type_of_elt))), size)
     | Scalar "string" ->
-      let n = Char.code buffer.[index] in
-      (String (Bytes.sub buffer (index+1) n), (1+n))
+      let n = Char.code (Bytes.get buffer index) in
+      (String (Bytes.to_string (Bytes.sub buffer (index+1) n)), (1+n))
     | _ -> failwith "value_of_bin"
 
 let value_field = fun buf index field ->
@@ -526,13 +526,13 @@ let rec sprint_value = fun buf i _type v ->
         sprint_value buf i (FixedArrayType ("char",l))
           (Array (Array.init (String.length value) (fun i -> Char (String.get value i))))
     | Scalar "string", String s ->
-      let n = Bytes.length s in
+        let n = String.length s in
       assert (n < 256);
       (** Put the length first, then the bytes *)
       Bytes.set buf i (Char.chr n);
       if (i + n >= Bytes.length buf) then
         failwith "Error in sprint_value: message too long";
-      Bytes.blit s 0 buf (i+1) n;
+          String.blit s 0 buf (i+1) n;
       1 + n
     | Scalar "char", Char c ->
         Bytes.set buf i c; sizeof _type
@@ -542,18 +542,17 @@ let rec sprint_value = fun buf i _type v ->
 
 
 let hex_of_int_array = function
-Array array ->
+  Array array ->
   let n = Array.length array in
       (* One integer -> 2 chars *)
   let s = Bytes.create (2*n) in
-  Array.iteri
-    (fun i dec ->
+    Array.iteri (fun i dec ->
       let x = int_of_value array.(i) in
       assert (0 <= x && x <= 0xff);
       let hex = sprintf "%02x" x in
-      Bytes.blit hex 0 s (2*i) 2)
-    array;
-  s
+      Bytes.blit_string hex 0 s (2*i) 2
+      ) array;
+    Bytes.to_string s
   | value ->
     failwith (sprintf "Error: expecting array in PprzLink.hex_of_int_array, found %s" (string_of_value value))
 
@@ -626,10 +625,10 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
 
 
   let values_of_payload = fun buffer ->
-    let buffer = Protocol.string_of_payload buffer in
+    let buffer = Protocol.bytes_of_payload buffer in
     try
-      let id = Char.code buffer.[offset_msg_id] in
-      let ac_id = Char.code buffer.[offset_ac_id] in
+      let id = Char.code (Bytes.get buffer offset_msg_id) in
+      let ac_id = Char.code (Bytes.get buffer offset_ac_id) in
       let message = message_of_id id in
       DebugPL.call 'T' (fun f -> fprintf f "PprzLink.values id=%d\n" id);
       let rec loop = fun index fields ->
@@ -638,14 +637,14 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
               if index = Bytes.length buffer then
                 []
               else
-                failwith (sprintf "PprzLink.values_of_payload, too many bytes in message %s: %s" message.name (DebugPL.xprint buffer))
+                failwith (sprintf "PprzLink.values_of_payload, too many bytes in message %s: %s" message.name (DebugPL.xprint (Bytes.to_string buffer)))
           | (field_name, field_descr)::fs ->
             let (value, n) = value_field buffer index field_descr in
             (field_name, value) :: loop (index+n) fs in
       (id, ac_id, loop offset_fields message.fields)
     with
         Invalid_argument _ ->
-          failwith (sprintf "PprzLink.values_of_payload, wrong argument: %s" (DebugPL.xprint buffer))
+          failwith (sprintf "PprzLink.values_of_payload, wrong argument: %s" (DebugPL.xprint (Bytes.to_string buffer)))
 
 
   let payload_of_values = fun id ac_id values ->
@@ -669,7 +668,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
 
     (** Cut to the actual length *)
     let p = Bytes.sub p 0 !i in
-    Protocol.payload_of_string p
+    Protocol.payload_of_bytes p
 
 
   let space = Str.regexp "[ \t]+"
@@ -707,7 +706,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
         then invalid_arg (sprintf "PprzLink.string_of_message: unknown field '%s' in message '%s'" k msg.name))
       values;
 
-    Bytes.concat sep
+    String.concat sep
       (msg.name::
          List.map
      (fun (field_name, field) ->
@@ -726,7 +725,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
           None -> ""
         | Some x -> sprintf "%f " x in
     let msg = sprintf "%s%s %s" timestamp_string sender s in
-    let n = Bytes.length msg in
+    let n = String.length msg in
     if n > 10000 then (** prevent really long Ivy message, should not happen with normal usage *)
       fprintf stderr "Discarding long ivy message %s (%d bytes)\n%!" msg_name n
     else
@@ -734,7 +733,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
         None -> Ivy.send msg
       | Some the_link_id -> begin
         let index = ref 0 in
-        let modified_msg = Bytes.copy msg in
+        let modified_msg = Bytes.of_string msg in
         let func = fun c ->
           match c with
             ' ' -> begin
@@ -743,7 +742,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
             end
           | x -> index := !index + 1; in
         Bytes.iter func modified_msg;
-        Ivy.send (Printf.sprintf "redlink TELEMETRY_MESSAGE %s %i %s" sender the_link_id modified_msg);
+        Ivy.send (Printf.sprintf "redlink TELEMETRY_MESSAGE %s %i %s" sender the_link_id (Bytes.to_string modified_msg));
       end
 
   let message_bind = fun ?sender ?(timestamp=false) msg_name cb ->

--- a/lib/v1.0/ocaml/pprzLink.mli
+++ b/lib/v1.0/ocaml/pprzLink.mli
@@ -2,7 +2,7 @@
  * PPRZLINK message protocol handling
  *
  * Copyright (C) 2003 Pascal Brisset, Antoine Drouin
- * Copyright (C) 2015 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Copyright (C) 2015-2020 Gautier Hattenberger <gautier.hattenberger@enac.fr>
  *
  * This file is part of paparazzi.
  *
@@ -50,9 +50,9 @@ type message = {
 (** Message specification *)
 
 
-external int32_of_bytes : string -> int -> int32 = "c_int32_of_indexed_bytes"
-external uint32_of_bytes : string -> int -> int64 = "c_uint32_of_indexed_bytes"
-external int64_of_bytes : string -> int -> int64 = "c_int64_of_indexed_bytes"
+external int32_of_bytes : bytes -> int -> int32 = "c_int32_of_indexed_bytes"
+external uint32_of_bytes : bytes -> int -> int64 = "c_uint32_of_indexed_bytes"
+external int64_of_bytes : bytes -> int -> int64 = "c_int64_of_indexed_bytes"
 (** [int32_of_bytes buffer offset] *)
 
 val separator : string
@@ -150,7 +150,7 @@ module type MESSAGES = sig
   val message_of_name : string ->  message_id * message
 
   val values_of_payload : Protocol.payload -> message_id * ac_id * values
-  (** [values_of_bin payload] Parses a raw payload, returns the
+  (** [values_of_payload payload] Parses a raw payload, returns the
    message id, the A/C id and the list of (field_name, value) *)
 
   val payload_of_values : message_id -> ac_id -> values -> Protocol.payload

--- a/lib/v2.0/ocaml/pprzLink.ml
+++ b/lib/v2.0/ocaml/pprzLink.ml
@@ -2,7 +2,7 @@
  * PPRZLINK message protocol handling
  *
  * Copyright (C) 2003 Pascal Brisset, Antoine Drouin
- * Copyright (C) 2015 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Copyright (C) 2015-2020 Gautier Hattenberger <gautier.hattenberger@enac.fr>
  *
  * This file is part of paparazzi.
  *
@@ -89,19 +89,19 @@ let lazy_messages_xml = lazy (Xml.parse_file messages_file)
 let messages_xml = fun () -> Lazy.force lazy_messages_xml
 let units_file = pprzlink_dir // "units.xml"
 
-external float_of_bytes : string -> int -> float = "c_float_of_indexed_bytes"
-external double_of_bytes : string -> int -> float = "c_double_of_indexed_bytes"
-external int8_of_bytes : string -> int -> int = "c_int8_of_indexed_bytes"
-external int16_of_bytes : string -> int -> int = "c_int16_of_indexed_bytes"
-external int32_of_bytes : string -> int -> int32 = "c_int32_of_indexed_bytes"
-external uint32_of_bytes : string -> int -> int64 = "c_uint32_of_indexed_bytes"
-external int64_of_bytes : string -> int -> int64 = "c_int64_of_indexed_bytes"
-external sprint_float : string -> int -> float -> unit = "c_sprint_float"
-external sprint_double : string -> int -> float -> unit = "c_sprint_double"
-external sprint_int64 : string -> int -> int64 -> unit = "c_sprint_int64"
-external sprint_int32 : string -> int -> int32 -> unit = "c_sprint_int32"
-external sprint_int16 : string -> int -> int -> unit = "c_sprint_int16"
-external sprint_int8 : string -> int -> int -> unit = "c_sprint_int8"
+external float_of_bytes : bytes -> int -> float = "c_float_of_indexed_bytes"
+external double_of_bytes : bytes -> int -> float = "c_double_of_indexed_bytes"
+external int8_of_bytes : bytes -> int -> int = "c_int8_of_indexed_bytes"
+external int16_of_bytes : bytes -> int -> int = "c_int16_of_indexed_bytes"
+external int32_of_bytes : bytes -> int -> int32 = "c_int32_of_indexed_bytes"
+external uint32_of_bytes : bytes -> int -> int64 = "c_uint32_of_indexed_bytes"
+external int64_of_bytes : bytes -> int -> int64 = "c_int64_of_indexed_bytes"
+external sprint_float : bytes -> int -> float -> unit = "c_sprint_float"
+external sprint_double : bytes -> int -> float -> unit = "c_sprint_double"
+external sprint_int64 : bytes -> int -> int64 -> unit = "c_sprint_int64"
+external sprint_int32 : bytes -> int -> int32 -> unit = "c_sprint_int32"
+external sprint_int16 : bytes -> int -> int -> unit = "c_sprint_int16"
+external sprint_int8 : bytes -> int -> int -> unit = "c_sprint_int8"
 
 let types = [
   ("uint8",  { format = "%u"; glib_type = "guint8"; inttype = "uint8_t";  size = 1; value=Int 42 });
@@ -119,12 +119,12 @@ let types = [
 ]
 
 let is_array_type = fun s ->
-  let n = Bytes.length s in
-  n >= 2 && Bytes.sub s (n-2) 2 = "[]"
+  let n = String.length s in
+  n >= 2 && String.sub s (n-2) 2 = "[]"
 
 let type_of_array_type = fun s ->
-  let n = Bytes.length s in
-  Bytes.sub s 0 (n-2)
+  let n = String.length s in
+  String.sub s 0 (n-2)
 
 let is_fixed_array_type = fun s ->
   let type_parts = Str.full_split (Str.regexp "[][]") s in
@@ -184,13 +184,13 @@ let rec string_of_value = function
   | Float x -> string_of_float x
   | Int32 x -> Int32.to_string x
   | Int64 x -> Int64.to_string x
-  | Char c -> Bytes.make 1 c
+  | Char c -> String.make 1 c
   | String s -> s
   | Array a ->
       let l = (Array.to_list (Array.map string_of_value a)) in
       match a.(0) with
-      | Char _ -> "\""^(Bytes.concat "" l)^"\""
-      | _ -> Bytes.concat separator l
+      | Char _ -> "\""^(String.concat "" l)^"\""
+      | _ -> String.concat separator l
 
 
 let rec formatted_string_of_value = fun format v ->
@@ -205,8 +205,8 @@ let rec formatted_string_of_value = fun format v ->
     | Array a ->
         let l = (Array.to_list (Array.map (formatted_string_of_value format) a)) in
         match a.(0) with
-        | Char _ -> "\""^(Bytes.concat "" l)^"\""
-        | _ -> Bytes.concat separator l
+        | Char _ -> "\""^(String.concat "" l)^"\""
+        | _ -> String.concat separator l
 
 
 let sizeof = fun f ->
@@ -339,7 +339,7 @@ let field_of_xml = fun xml ->
     { _type = t; fformat = f; alt_unit_coef = auc; enum=values })
 
 let string_of_values = fun vs ->
-  Bytes.concat " " (List.map (fun (a,v) -> sprintf "%s=%s" a (string_of_value v)) vs)
+  String.concat " " (List.map (fun (a,v) -> sprintf "%s=%s" a (string_of_value v)) vs)
 
 let assoc = fun a vs ->
   try List.assoc (CompatPL.lowercase_ascii a) vs with Not_found ->
@@ -424,10 +424,10 @@ let parse_class = fun xml_class ->
 (** Returns a value and its length *)
 let rec value_of_bin = fun buffer index _type ->
   match _type with
-      Scalar "uint8" -> Int (Char.code buffer.[index]), sizeof _type
-    | Scalar "char" -> Char (buffer.[index]), sizeof _type
+      Scalar "uint8" -> Int (Char.code (Bytes.get buffer index)), sizeof _type
+    | Scalar "char" -> Char (Bytes.get buffer index), sizeof _type
     | Scalar "int8" -> Int (int8_of_bytes buffer index), sizeof _type
-    | Scalar "uint16" -> Int (Char.code buffer.[index+1] lsl 8 + Char.code buffer.[index]), sizeof _type
+    | Scalar "uint16" -> Int (Char.code (Bytes.get buffer (index+1)) lsl 8 + Char.code (Bytes.get buffer index)), sizeof _type
     | Scalar "int16" -> Int (int16_of_bytes buffer index), sizeof _type
     | Scalar "float" -> Float (float_of_bytes buffer index), sizeof _type
     | Scalar "double" -> Float (double_of_bytes buffer index), sizeof _type
@@ -436,7 +436,7 @@ let rec value_of_bin = fun buffer index _type ->
     | Scalar ("int64"  | "uint64") -> Int64 (int64_of_bytes buffer index), sizeof _type
     | ArrayType t ->
       (** First get the number of values *)
-      let n = Char.code buffer.[index] in
+      let n = Char.code (Bytes.get buffer index) in
       let type_of_elt = Scalar t in
       let s = sizeof type_of_elt in
       let size = 1 + n * s in
@@ -451,8 +451,8 @@ let rec value_of_bin = fun buffer index _type ->
       (Array (Array.init n
          (fun i -> fst (value_of_bin buffer (index+0+i*s) type_of_elt))), size)
     | Scalar "string" ->
-      let n = Char.code buffer.[index] in
-      (String (Bytes.sub buffer (index+1) n), (1+n))
+      let n = Char.code (Bytes.get buffer index) in
+      (String (Bytes.to_string (Bytes.sub buffer (index+1) n)), (1+n))
     | _ -> failwith "value_of_bin"
 
 let value_field = fun buf index field ->
@@ -530,13 +530,13 @@ let rec sprint_value = fun buf i _type v ->
         sprint_value buf i (FixedArrayType ("char",l))
           (Array (Array.init (String.length value) (fun i -> Char (String.get value i))))
     | Scalar "string", String s ->
-        let n = Bytes.length s in
+        let n = String.length s in
         assert (n < 256);
         (** Put the length first, then the bytes *)
         Bytes.set buf i (Char.chr n);
         if (i + n >= Bytes.length buf) then
           failwith "Error in sprint_value: message too long";
-          Bytes.blit s 0 buf (i+1) n;
+          String.blit s 0 buf (i+1) n;
           1 + n
     | Scalar "char", Char c ->
         Bytes.set buf i c; sizeof _type
@@ -546,20 +546,19 @@ let rec sprint_value = fun buf i _type v ->
 
 
 let hex_of_int_array = function
-Array array ->
-  let n = Array.length array in
-      (* One integer -> 2 chars *)
-  let s = Bytes.create (2*n) in
-  Array.iteri
-    (fun i dec ->
+  Array array ->
+    let n = Array.length array in
+    (* One integer -> 2 chars *)
+    let s = Bytes.create (2*n) in
+    Array.iteri (fun i dec ->
       let x = int_of_value array.(i) in
       assert (0 <= x && x <= 0xff);
       let hex = sprintf "%02x" x in
-      Bytes.blit hex 0 s (2*i) 2)
-    array;
-  s
+      Bytes.blit_string hex 0 s (2*i) 2
+      ) array;
+    Bytes.to_string s
   | value ->
-    failwith (sprintf "Error: expecting array in PprzLink.hex_of_int_array, found %s" (string_of_value value))
+        failwith (sprintf "Error: expecting array in PprzLink.hex_of_int_array, found %s" (string_of_value value))
 
 
 
@@ -646,11 +645,11 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
 
 
   let values_of_payload = fun buffer ->
-    let buffer = Protocol.string_of_payload buffer in
+    let buffer = Protocol.bytes_of_payload buffer in
     try
-      let id = Char.code buffer.[offset_msg_id] in
-      let sender_id = Char.code buffer.[offset_sender_id] in
-      let c_id = value_of_byte (Char.code buffer.[offset_class_id]) mask_class_id shift_class_id in
+      let id = Char.code (Bytes.get buffer offset_msg_id) in
+      let sender_id = Char.code (Bytes.get buffer offset_sender_id) in
+      let c_id = value_of_byte (Char.code (Bytes.get buffer offset_class_id)) mask_class_id shift_class_id in
       if not (valid_class_id c_id) then failwith (sprintf "PprzLink.invalid class ID %d" c_id);
       let message = message_of_id id in
       DebugPL.call 'T' (fun f -> fprintf f "PprzLink.values id=%d\n" id);
@@ -660,14 +659,14 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
               if index = Bytes.length buffer then
                 []
               else
-                failwith (sprintf "PprzLink.values_of_payload, too many bytes in message %s: %s" message.name (DebugPL.xprint buffer))
+                failwith (sprintf "PprzLink.values_of_payload, too many bytes in message %s: %s" message.name (DebugPL.xprint (Bytes.to_string buffer)))
           | (field_name, field_descr)::fs ->
             let (value, n) = value_field buffer index field_descr in
             (field_name, value) :: loop (index+n) fs in
       (id, sender_id, loop offset_fields message.fields)
     with
         Invalid_argument _ ->
-          failwith (sprintf "PprzLink.values_of_payload, wrong argument: %s" (DebugPL.xprint buffer))
+          failwith (sprintf "PprzLink.values_of_payload, wrong argument: %s" (DebugPL.xprint (Bytes.to_string buffer)))
 
 
   let payload_of_values = fun id sender_id values ->
@@ -694,7 +693,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
 
     (** Cut to the actual length *)
     let p = Bytes.sub p 0 !i in
-    Protocol.payload_of_string p
+    Protocol.payload_of_bytes p
 
 
   let space = Str.regexp "[ \t]+"
@@ -732,7 +731,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
         then invalid_arg (sprintf "PprzLink.string_of_message: unknown field '%s' in message '%s'" k msg.name))
       values;
 
-    Bytes.concat sep
+    String.concat sep
       (msg.name::
          List.map
      (fun (field_name, field) ->
@@ -751,7 +750,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
           None -> ""
         | Some x -> sprintf "%f " x in
     let msg = sprintf "%s%s %s" timestamp_string sender s in
-    let n = Bytes.length msg in
+    let n = String.length msg in
     if n > 10000 then (** prevent really long Ivy message, should not happen with normal usage *)
       fprintf stderr "Discarding long ivy message %s (%d bytes)\n%!" msg_name n
     else
@@ -759,7 +758,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
         None -> Ivy.send msg
       | Some the_link_id -> begin
         let index = ref 0 in
-        let modified_msg = Bytes.copy msg in
+        let modified_msg = Bytes.of_string msg in
         let func = fun c ->
           match c with
             ' ' -> begin
@@ -768,7 +767,7 @@ module MessagesOfXml(Class:CLASS_Xml) = struct
             end
           | x -> index := !index + 1; in
         Bytes.iter func modified_msg;
-        Ivy.send (Printf.sprintf "redlink TELEMETRY_MESSAGE %s %i %s" sender the_link_id modified_msg);
+        Ivy.send (Printf.sprintf "redlink TELEMETRY_MESSAGE %s %i %s" sender the_link_id (Bytes.to_string modified_msg));
       end
 
   let message_bind = fun ?sender ?(timestamp=false) msg_name cb ->

--- a/lib/v2.0/ocaml/pprzLink.mli
+++ b/lib/v2.0/ocaml/pprzLink.mli
@@ -2,7 +2,7 @@
  * PPRZLINK message protocol handling
  *
  * Copyright (C) 2003 Pascal Brisset, Antoine Drouin
- * Copyright (C) 2015-2017 Gautier Hattenberger <gautier.hattenberger@enac.fr>
+ * Copyright (C) 2015-2020 Gautier Hattenberger <gautier.hattenberger@enac.fr>
  *
  * This file is part of paparazzi.
  *
@@ -53,9 +53,9 @@ type message = {
 (** Message specification *)
 
 
-external int32_of_bytes : string -> int -> int32 = "c_int32_of_indexed_bytes"
-external uint32_of_bytes : string -> int -> int64 = "c_uint32_of_indexed_bytes"
-external int64_of_bytes : string -> int -> int64 = "c_int64_of_indexed_bytes"
+external int32_of_bytes : bytes -> int -> int32 = "c_int32_of_indexed_bytes"
+external uint32_of_bytes : bytes -> int -> int64 = "c_uint32_of_indexed_bytes"
+external int64_of_bytes : bytes -> int -> int64 = "c_int64_of_indexed_bytes"
 (** [int32_of_bytes buffer offset] *)
 
 val separator : string
@@ -152,7 +152,7 @@ module type MESSAGES = sig
   val message_of_name : string ->  message_id * message
 
   val values_of_payload : Protocol.payload -> message_id * sender_id * values
-  (** [values_of_bin payload] Parses a raw payload, returns the
+  (** [values_of_payload payload] Parses a raw payload, returns the
    message id, the A/C id and the list of (field_name, value) *)
 
   val payload_of_values : message_id -> sender_id -> values -> Protocol.payload


### PR DESCRIPTION
It turns out that the way we were using Bytes and String modules was completely wrong and only working because `-usafe-string` option was the default behavior. It will no longer be the case in future version, so better get this right now.
It enforce a strong type checking for everyone to avoid errors.

Main Paparazzi code will be updated accordingly.