### PR TITLE
fix warning of gcc9 Waddress-of-packed-member

### DIFF
--- a/tools/generator/C/include_v2.0/pprzlink_utils.h
+++ b/tools/generator/C/include_v2.0/pprzlink_utils.h
@@ -65,9 +65,7 @@ extern "C" {
 
 // This way of reading is more efficient when data is actually aligned
 // but is still working if the CPU/MMU supports unaligned access.
-// The use of 'packed' forces the compiler to assume no better
-// than 1-byte alignment, and issue sequential byte reads/writes.
-typedef union __attribute__((packed)) {
+typedef union __attribute__((aligned(1))) {
   int16_t   int16;
   uint16_t  uint16;
   int32_t   int32;
@@ -78,15 +76,15 @@ typedef union __attribute__((packed)) {
   double    f64;
 } unaligned_t;
 
-#define _PPRZ_VAL_int16_t(_payload, _offset) (((unaligned_t*)(_payload+_offset))->int16)
-#define _PPRZ_VAL_uint16_t(_payload, _offset) (((unaligned_t*)(_payload+_offset))->uint16)
-#define _PPRZ_VAL_int32_t(_payload, _offset) (((unaligned_t*)(_payload+_offset))->int32)
-#define _PPRZ_VAL_uint32_t(_payload, _offset) (((unaligned_t*)(_payload+_offset))->uint32)
-#define _PPRZ_VAL_int64_t(_payload, _offset) (((unaligned_t*)(_payload+_offset))->int64)
-#define _PPRZ_VAL_uint64_t(_payload, _offset) (((unaligned_t*)(_payload+_offset))->uint64)
-#define _PPRZ_VAL_float(_payload, _offset) (((unaligned_t*)(_payload+_offset))->f32)
+#define _PPRZ_VAL_int16_t(_payload, _offset) (((unaligned_t*)((uint8_t*)_payload+_offset))->int16)
+#define _PPRZ_VAL_uint16_t(_payload, _offset) (((unaligned_t*)((uint8_t*)_payload+_offset))->uint16)
+#define _PPRZ_VAL_int32_t(_payload, _offset) (((unaligned_t*)((uint8_t*)_payload+_offset))->int32)
+#define _PPRZ_VAL_uint32_t(_payload, _offset) (((unaligned_t*)((uint8_t*)_payload+_offset))->uint32)
+#define _PPRZ_VAL_int64_t(_payload, _offset) (((unaligned_t*)((uint8_t*)_payload+_offset))->int64)
+#define _PPRZ_VAL_uint64_t(_payload, _offset) (((unaligned_t*)((uint8_t*)_payload+_offset))->uint64)
+#define _PPRZ_VAL_float(_payload, _offset) (((unaligned_t*)((uint8_t*)_payload+_offset))->f32)
 #ifndef __IEEE_BIG_ENDIAN
-#define _PPRZ_VAL_double(_payload, _offset) (((unaligned_t*)(_payload+_offset))->f64)
+#define _PPRZ_VAL_double(_payload, _offset) (((unaligned_t*)((uint8_t*)_payload+_offset))->f64)
 #else
 #define _PPRZ_VAL_double(_payload, _offset) ({ \
     union { uint64_t u; double f; } _f; \
@@ -96,14 +94,14 @@ typedef union __attribute__((packed)) {
 #endif
 
 // In this case, data is not aligned but we are still able to read them
-#define _PPRZ_VAL_int16_t_array(_payload, _offset) (&_PPRZ_VAL_int16_t(_payload, _offset))
-#define _PPRZ_VAL_uint16_t_array(_payload, _offset) (&_PPRZ_VAL_uint16_t(_payload, _offset))
-#define _PPRZ_VAL_int32_t_array(_payload, _offset) (&_PPRZ_VAL_int32_t(_payload, _offset))
-#define _PPRZ_VAL_uint32_t_array(_payload, _offset) (&_PPRZ_VAL_uint32_t(_payload, _offset))
-#define _PPRZ_VAL_int64_t_array(_payload, _offset) (&_PPRZ_VAL_int64_t(_payload, _offset))
-#define _PPRZ_VAL_uint64_t_array(_payload, _offset) (&_PPRZ_VAL_uint64_t(_payload, _offset))
-#define _PPRZ_VAL_float_array(_payload, _offset) (&_PPRZ_VAL_float(_payload, _offset))
-#define _PPRZ_VAL_double_array(_payload, _offset) (&_PPRZ_VAL_double(_payload, _offset))
+static inline int16_t * _PPRZ_VAL_int16_t_array(uint8_t *_payload, uint8_t _offset) { return &_PPRZ_VAL_int16_t(_payload, _offset); }
+static inline uint16_t * _PPRZ_VAL_uint16_t_array(uint8_t *_payload, uint8_t _offset) { return &_PPRZ_VAL_uint16_t(_payload, _offset); }
+static inline int32_t * _PPRZ_VAL_int32_t_array(uint8_t *_payload, uint8_t _offset) { return &_PPRZ_VAL_int32_t(_payload, _offset); }
+static inline uint32_t * _PPRZ_VAL_uint32_t_array(uint8_t *_payload, uint8_t _offset) { return &_PPRZ_VAL_uint32_t(_payload, _offset); }
+static inline int64_t * _PPRZ_VAL_int64_t_array(uint8_t *_payload, uint8_t _offset) { return &_PPRZ_VAL_int64_t(_payload, _offset); }
+static inline uint64_t * _PPRZ_VAL_uint64_t_array(uint8_t *_payload, uint8_t _offset) { return &_PPRZ_VAL_uint64_t(_payload, _offset); }
+static inline float * _PPRZ_VAL_float_array(uint8_t *_payload, uint8_t _offset) { return &_PPRZ_VAL_float(_payload, _offset); }
+static inline double * _PPRZ_VAL_double_array(uint8_t *_payload, uint8_t _offset) { return &_PPRZ_VAL_double(_payload, _offset); }
 #define _PPRZ_VAL_len_aligned(_payload, _offset) _PPRZ_VAL_uint8_t(_payload, _offset)
 #define _PPRZ_VAL_fixed_len_aligned(_len) (_len)
 


### PR DESCRIPTION
union of basic types should be aligned, not packed

hopefully the last modification for ubuntu 20.04 / GCC9