### PR TITLE
fix encoding of payload to ivy string format

### DIFF
--- a/lib/v2.0/python/pprzlink/message.py
+++ b/lib/v2.0/python/pprzlink/message.py
@@ -181,7 +181,7 @@ class PprzMessage(object):
             if "char[" in t:
                 str_value =''
                 for c in self.fieldvalues[idx]:
-                    if sys.version_info >= (3,):
+                    if isinstance(c, bytes):
                         str_value += c.decode()
                     else:
                         str_value += c


### PR DESCRIPTION
the fix in #103 was based on the python version
the way to add element is not related to the version in fact, but to the
type of element to add (bytes or str)
this should fix the problem in all cases