### PR TITLE
Using logging module instead of raw print statements

### DIFF
--- a/lib/v1.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v1.0/python/pprzlink/messages_xml_map.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, print_function
 
 import os
+import logging
 
 # if PAPARAZZI_HOME is set use $PAPARAZZI_HOME/var/messages.xml
 # else assume this file is installed in var/lib/python/pprzlink
@@ -24,6 +25,8 @@ message_dictionary_coefs = {}
 message_dictionary_id_name = {}
 message_dictionary_name_id = {}
 message_dictionary_broadcast = {}
+
+logger = logging.getLogger("PprzLink")
 
 
 class MessagesNotFound(Exception):
@@ -96,7 +99,7 @@ def find_msg_by_name(name):
         if name in message_dictionary[msg_class]:
             #print("found msg name %s in class %s" % (name, msg_class))
             return msg_class, name
-    print("Error: msg_name %s not found." % name)
+    logger.error("Error: msg_name %s not found." % name)
     return None, None
 
 
@@ -105,7 +108,7 @@ def get_msgs(msg_class):
     if msg_class in message_dictionary:
         return message_dictionary[msg_class]
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return []
 
 
@@ -115,9 +118,9 @@ def get_msg_name(msg_class, msg_id):
         if msg_id in message_dictionary_id_name[msg_class]:
             return message_dictionary_id_name[msg_class][msg_id]
         else:
-            print("Error: msg_id %d not found in msg_class %s." % (msg_id, msg_class))
+            logger.error("Error: msg_id %d not found in msg_class %s." % (msg_id, msg_class))
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return ""
 
 
@@ -127,9 +130,9 @@ def get_msg_fields(msg_class, msg_name):
         if msg_name in message_dictionary[msg_class]:
             return message_dictionary[msg_class][msg_name]
         else:
-            print("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
+            logger.error("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return []
 
 
@@ -138,7 +141,7 @@ def get_msg_id(msg_class, msg_name):
     try:
         return message_dictionary_name_id[msg_class][msg_name]
     except KeyError:
-        print("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
+        logger.error("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
         return 0
 
 
@@ -148,9 +151,9 @@ def get_msg_fieldtypes(msg_class, msg_id):
         if msg_id in message_dictionary_types[msg_class]:
             return message_dictionary_types[msg_class][msg_id]
         else:
-            print("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
+            logger.error("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return []
 
 def get_msg_fieldcoefs(msg_class, msg_id):
@@ -159,9 +162,9 @@ def get_msg_fieldcoefs(msg_class, msg_id):
         if msg_id in message_dictionary_coefs[msg_class]:
             return message_dictionary_coefs[msg_class][msg_id]
         else:
-            print("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
+            logger.error("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return []
 
 

--- a/lib/v1.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v1.0/python/pprzlink/messages_xml_map.py
@@ -85,9 +85,13 @@ def parse_messages(messages_file=''):
                     message_dictionary_coefs[class_name][message_id].append(1.)
 
 
-def find_msg_by_name(name):
-    if not message_dictionary:
+def _ensure_message_dictionary():
+    if message_dictionary is None:
         parse_messages()
+
+
+def find_msg_by_name(name):
+    _ensure_message_dictionary()
     for msg_class in message_dictionary:
         if name in message_dictionary[msg_class]:
             #print("found msg name %s in class %s" % (name, msg_class))
@@ -97,8 +101,7 @@ def find_msg_by_name(name):
 
 
 def get_msgs(msg_class):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary:
         return message_dictionary[msg_class]
     else:
@@ -107,8 +110,7 @@ def get_msgs(msg_class):
 
 
 def get_msg_name(msg_class, msg_id):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary:
         if msg_id in message_dictionary_id_name[msg_class]:
             return message_dictionary_id_name[msg_class][msg_id]
@@ -120,8 +122,7 @@ def get_msg_name(msg_class, msg_id):
 
 
 def get_msg_fields(msg_class, msg_name):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary:
         if msg_name in message_dictionary[msg_class]:
             return message_dictionary[msg_class][msg_name]
@@ -133,8 +134,7 @@ def get_msg_fields(msg_class, msg_name):
 
 
 def get_msg_id(msg_class, msg_name):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     try:
         return message_dictionary_name_id[msg_class][msg_name]
     except KeyError:
@@ -143,8 +143,7 @@ def get_msg_id(msg_class, msg_name):
 
 
 def get_msg_fieldtypes(msg_class, msg_id):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary_types:
         if msg_id in message_dictionary_types[msg_class]:
             return message_dictionary_types[msg_class][msg_id]
@@ -155,8 +154,7 @@ def get_msg_fieldtypes(msg_class, msg_id):
     return []
 
 def get_msg_fieldcoefs(msg_class, msg_id):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary_coefs:
         if msg_id in message_dictionary_coefs[msg_class]:
             return message_dictionary_coefs[msg_class][msg_id]

--- a/lib/v1.0/python/pprzlink/pprz_transport.py
+++ b/lib/v1.0/python/pprzlink/pprz_transport.py
@@ -3,7 +3,7 @@ Paparazzi transport encoding utilities
 
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division
 import struct
 from .message import PprzMessage
 

--- a/lib/v1.0/python/pprzlink/serial.py
+++ b/lib/v1.0/python/pprzlink/serial.py
@@ -2,9 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 import serial
+import logging
 
 from .message import PprzMessage
 from .pprz_transport import PprzTransport
+
+logger = logging.getLogger("PprzLink")
 
 
 class SerialMessagesInterface(threading.Thread):
@@ -18,12 +21,12 @@ class SerialMessagesInterface(threading.Thread):
         try:
             self.ser = serial.Serial(device, baudrate, timeout=1.0)
         except serial.SerialException:
-            print("Error: unable to open serial port '%s'" % device)
+            logger.error("Error: unable to open serial port '%s'" % device)
             exit(0)
         self.trans = PprzTransport(msg_class)
 
     def stop(self):
-        print("End thread and close serial link")
+        logger.info("End thread and close serial link")
         self.running = False
         self.ser.close()
 
@@ -52,8 +55,8 @@ class SerialMessagesInterface(threading.Thread):
                 if len(c) == 1:
                     if self.trans.parse_byte(c):
                         (sender_id, msg) = self.trans.unpack()
-                        if self.verbose:
-                            print("New incoming message '%s' from %i" % (msg.name, sender_id))
+                        if self.verbose:  # Can be replaced with the log level
+                            logger.info("New incoming message '%s' from %i" % (msg.name, sender_id))
                         # Callback function on new message 
                         self.callback(sender_id, msg)
 

--- a/lib/v1.0/python/pprzlink/udp.py
+++ b/lib/v1.0/python/pprzlink/udp.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 import socket
+import logging
 
 # load pprzlink messages and transport
 from .message import PprzMessage
@@ -13,6 +14,9 @@ from .pprz_transport import PprzTransport
 # default port
 UPLINK_PORT = 4243
 DOWNLINK_PORT = 4242
+
+
+logger = logging.getLogger("PprzLink")
 
 
 class UdpMessagesInterface(threading.Thread):
@@ -33,12 +37,12 @@ class UdpMessagesInterface(threading.Thread):
             self.server.settimeout(2.0)
             self.server.bind(('0.0.0.0', self.downlink_port))
         except OSError:
-            print("Error: unable to open socket on ports '%d' (up) and '%d' (down)" % (self.uplink_port, self.downlink_port))
+            logger.error("Error: unable to open socket on ports '%d' (up) and '%d' (down)" % (self.uplink_port, self.downlink_port))
             exit(0)
         self.trans = PprzTransport(msg_class)
 
     def stop(self):
-        print("End thread and close UDP link")
+        logger.info("End thread and close UDP link")
         self.running = False
         self.server.close()
 
@@ -72,8 +76,8 @@ class UdpMessagesInterface(threading.Thread):
                         if self.trans.parse_byte(c):
                             (sender_id, msg) = self.trans.unpack()
                             if self.verbose:
-                                print("New incoming message '%s' from %i (%s)" % (msg.name, sender_id, address))
-                            # Callback function on new message 
+                                logger.info("New incoming message '%s' from %i (%s)" % (msg.name, sender_id, address))
+                            # Callback function on new message
                             self.callback(sender_id, address, msg, length)
                 except socket.timeout:
                     pass

--- a/lib/v2.0/python/pprzlink/ivy.py
+++ b/lib/v2.0/python/pprzlink/ivy.py
@@ -1,10 +1,9 @@
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division
 
 from ivy.std_api import *
 from ivy.ivy import IvyIllegalStateError
 import logging
 import os
-import sys
 import re
 import platform
 
@@ -18,6 +17,8 @@ elif platform.system() == 'Darwin':
     IVY_BUS = "224.255.255.255:2010"
 else:
     IVY_BUS = ""
+
+logger = logging.getLogger("PpzLink")
 
 
 class IvyMessagesInterface(object):
@@ -47,7 +48,7 @@ class IvyMessagesInterface(object):
         try:
             self.shutdown()
         except Exception as e:
-            print(e)
+            logger.error(e)
 
     def start(self):
         if not self._running:
@@ -69,7 +70,7 @@ class IvyMessagesInterface(object):
             self.unsubscribe_all()
             self.stop()
         except IvyIllegalStateError as e:
-            print(e)
+            logger.error(e)
 
     def bind_raw(self, callback, regex='(.*)'):
         """
@@ -139,7 +140,7 @@ class IvyMessagesInterface(object):
         # check which message class it is
         msg_class, msg_name = messages_xml_map.find_msg_by_name(msg_name)
         if msg_class is None:
-            print("Ignoring unknown message " + ivy_msg)
+            logger.error("Ignoring unknown message " + ivy_msg)
             return
         msg = PprzMessage(msg_class, msg_name)
         msg.ivy_string_to_payload(payload)
@@ -151,8 +152,7 @@ class IvyMessagesInterface(object):
                 else:
                     ac_id = int(sender_name)
             except ValueError:
-                print("ignoring message " + ivy_msg)
-                sys.stdout.flush()
+                logger.warning("ignoring message " + ivy_msg)
         else:
             if 'ac_id' in msg.fieldnames:
                 ac_id_idx = msg.fieldnames.index('ac_id')
@@ -170,10 +170,10 @@ class IvyMessagesInterface(object):
         :returns: Number of clients the message sent to, None if msg was invalid
         """
         if not isinstance(msg, PprzMessage):
-            print("Can only send PprzMessage")
+            logger.error("Can only send PprzMessage")
             return None
         if "datalink" not in msg.msg_class:
-            print("Message to embed in RAW_DATALINK needs to be of 'datalink' class")
+            logger.error("Message to embed in RAW_DATALINK needs to be of 'datalink' class")
             return None
         raw = PprzMessage("ground", "RAW_DATALINK")
         raw['ac_id'] = msg['ac_id']
@@ -189,12 +189,12 @@ class IvyMessagesInterface(object):
         :returns: Number of clients the message sent to, None if msg was invalid
         """
         if not self._running:
-            print("Ivy server not running!")
+            logger.error("Ivy server not running!")
             return
         if isinstance(msg, PprzMessage):
             if "telemetry" in msg.msg_class:
                 if sender_id is None:
-                    print("ac_id needed to send telemetry message.")
+                    logger.error("ac_id needed to send telemetry message.")
                     return None
                 else:
                     return IvySendMsg("%d %s %s" % (sender_id, msg.name, msg.payload_to_ivy_string()))

--- a/lib/v2.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v2.0/python/pprzlink/messages_xml_map.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, print_function
 
 import os
+import logging
 
 # if PAPARAZZI_HOME is set use $PAPARAZZI_HOME/var/messages.xml
 # else assume this file is installed in var/lib/python/pprzlink
@@ -26,6 +27,9 @@ message_dictionary_name_id = {}
 message_dictionary_class_id_name = {}
 message_dictionary_class_name_id = {}
 message_dictionary_broadcast = {}
+
+logger = logging.getLogger("PprzLink")
+
 
 class MessagesNotFound(Exception):
     def __init__(self, filename):
@@ -106,7 +110,7 @@ def find_msg_by_name(name):
         if name in message_dictionary[msg_class]:
             #print("found msg name %s in class %s" % (name, msg_class))
             return msg_class, name
-    print("Error: msg_name %s not found." % name)
+    logger.error("Error: msg_name %s not found." % name)
     return None, None
 
 
@@ -115,7 +119,7 @@ def get_msgs(msg_class):
     if msg_class in message_dictionary:
         return message_dictionary[msg_class]
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return []
 
 
@@ -124,7 +128,7 @@ def get_class_name(class_id):
     if class_id in message_dictionary_class_id_name:
         return message_dictionary_class_id_name[class_id]
     else:
-        print("Error: class_id %d not found." % class_id)
+        logger.error("Error: class_id %d not found." % class_id)
     return None
 
 def get_class_id(class_name):
@@ -132,7 +136,7 @@ def get_class_id(class_name):
     if class_name in message_dictionary_class_name_id:
         return message_dictionary_class_name_id[class_name]
     else:
-        print("Error: class_name %s not found." % class_name)
+        logger.error("Error: class_name %s not found." % class_name)
     return None
 
 
@@ -142,9 +146,9 @@ def get_msg_name(msg_class, msg_id):
         if msg_id in message_dictionary_id_name[msg_class]:
             return message_dictionary_id_name[msg_class][msg_id]
         else:
-            print("Error: msg_id %d not found in msg_class %s." % (msg_id, msg_class))
+            logger.error("Error: msg_id %d not found in msg_class %s." % (msg_id, msg_class))
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return ""
 
 
@@ -154,9 +158,9 @@ def get_msg_fields(msg_class, msg_name):
         if msg_name in message_dictionary[msg_class]:
             return message_dictionary[msg_class][msg_name]
         else:
-            print("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
+            logger.error("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return []
 
 
@@ -165,7 +169,7 @@ def get_msg_id(msg_class, msg_name):
     try:
         return message_dictionary_name_id[msg_class][msg_name]
     except KeyError:
-        print("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
+        logger.error("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
         return 0
 
 
@@ -175,9 +179,9 @@ def get_msg_fieldtypes(msg_class, msg_id):
         if msg_id in message_dictionary_types[msg_class]:
             return message_dictionary_types[msg_class][msg_id]
         else:
-            print("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
+            logger.error("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return []
 
 def get_msg_fieldcoefs(msg_class, msg_id):
@@ -186,9 +190,9 @@ def get_msg_fieldcoefs(msg_class, msg_id):
         if msg_id in message_dictionary_coefs[msg_class]:
             return message_dictionary_coefs[msg_class][msg_id]
         else:
-            print("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
+            logger.error("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
     else:
-        print("Error: msg_class %s not found." % msg_class)
+        logger.error("Error: msg_class %s not found." % msg_class)
     return []
 
 

--- a/lib/v2.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v2.0/python/pprzlink/messages_xml_map.py
@@ -95,9 +95,13 @@ def parse_messages(messages_file=''):
                     message_dictionary_coefs[class_name][message_id].append(1.)
 
 
-def find_msg_by_name(name):
-    if not message_dictionary:
+def _ensure_message_dictionary():
+    if message_dictionary is None:
         parse_messages()
+
+
+def find_msg_by_name(name):
+    _ensure_message_dictionary()
     for msg_class in message_dictionary:
         if name in message_dictionary[msg_class]:
             #print("found msg name %s in class %s" % (name, msg_class))
@@ -107,8 +111,7 @@ def find_msg_by_name(name):
 
 
 def get_msgs(msg_class):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary:
         return message_dictionary[msg_class]
     else:
@@ -117,8 +120,7 @@ def get_msgs(msg_class):
 
 
 def get_class_name(class_id):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if class_id in message_dictionary_class_id_name:
         return message_dictionary_class_id_name[class_id]
     else:
@@ -126,8 +128,7 @@ def get_class_name(class_id):
     return None
 
 def get_class_id(class_name):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if class_name in message_dictionary_class_name_id:
         return message_dictionary_class_name_id[class_name]
     else:
@@ -136,8 +137,7 @@ def get_class_id(class_name):
 
 
 def get_msg_name(msg_class, msg_id):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary:
         if msg_id in message_dictionary_id_name[msg_class]:
             return message_dictionary_id_name[msg_class][msg_id]
@@ -149,8 +149,7 @@ def get_msg_name(msg_class, msg_id):
 
 
 def get_msg_fields(msg_class, msg_name):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary:
         if msg_name in message_dictionary[msg_class]:
             return message_dictionary[msg_class][msg_name]
@@ -162,8 +161,7 @@ def get_msg_fields(msg_class, msg_name):
 
 
 def get_msg_id(msg_class, msg_name):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     try:
         return message_dictionary_name_id[msg_class][msg_name]
     except KeyError:
@@ -172,8 +170,7 @@ def get_msg_id(msg_class, msg_name):
 
 
 def get_msg_fieldtypes(msg_class, msg_id):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary_types:
         if msg_id in message_dictionary_types[msg_class]:
             return message_dictionary_types[msg_class][msg_id]
@@ -184,8 +181,7 @@ def get_msg_fieldtypes(msg_class, msg_id):
     return []
 
 def get_msg_fieldcoefs(msg_class, msg_id):
-    if not message_dictionary:
-        parse_messages()
+    _ensure_message_dictionary()
     if msg_class in message_dictionary_coefs:
         if msg_id in message_dictionary_coefs[msg_class]:
             return message_dictionary_coefs[msg_class][msg_id]

--- a/lib/v2.0/python/pprzlink/pprz_transport.py
+++ b/lib/v2.0/python/pprzlink/pprz_transport.py
@@ -3,7 +3,7 @@ Paparazzi transport encoding utilities
 
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division
 import struct
 from pprzlink.message import PprzMessage
 

--- a/lib/v2.0/python/pprzlink/serial.py
+++ b/lib/v2.0/python/pprzlink/serial.py
@@ -2,9 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 import serial
+import logging
+
 
 from pprzlink.message import PprzMessage
 from pprzlink.pprz_transport import PprzTransport
+
+
+logger = logging.getLogger("PprzLink")
 
 
 class SerialMessagesInterface(threading.Thread):
@@ -19,12 +24,12 @@ class SerialMessagesInterface(threading.Thread):
         try:
             self.ser = serial.Serial(device, baudrate, timeout=1.0)
         except serial.SerialException:
-            print("Error: unable to open serial port '%s'" % device)
+            logger.error("Error: unable to open serial port '%s'" % device)
             exit(0)
         self.trans = PprzTransport(msg_class)
 
     def stop(self):
-        print("End thread and close serial link")
+        logger.info("End thread and close serial link")
         self.running = False
         self.ser.close()
 
@@ -53,8 +58,8 @@ class SerialMessagesInterface(threading.Thread):
                 if len(c) == 1:
                     if self.trans.parse_byte(c):
                         (sender_id, receiver_id, component_id, msg) = self.trans.unpack()
-                        if self.verbose:
-                            print("New incoming message '%s' from %i (%i) to %i" % (msg.name, sender_id, component_id, receiver_id))
+                        if self.verbose:  # See the note on the same line in v1.0
+                            logger.info("New incoming message '%s' from %i (%i) to %i" % (msg.name, sender_id, component_id, receiver_id))
                         # Callback function on new message
                         if self.id == receiver_id:
                             self.callback(sender_id, msg)

--- a/lib/v2.0/python/pprzlink/udp.py
+++ b/lib/v2.0/python/pprzlink/udp.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 import socket
+import logging
 
 # load pprzlink messages and transport
 from pprzlink.message import PprzMessage
@@ -13,6 +14,9 @@ from pprzlink.pprz_transport import PprzTransport
 # default port
 UPLINK_PORT = 4243
 DOWNLINK_PORT = 4242
+
+
+logger = logging.getLogger("PprzLink")
 
 
 class UdpMessagesInterface(threading.Thread):
@@ -34,12 +38,12 @@ class UdpMessagesInterface(threading.Thread):
             self.server.settimeout(2.0)
             self.server.bind(('0.0.0.0', self.downlink_port))
         except OSError:
-            print("Error: unable to open socket on ports '%d' (up) and '%d' (down)" % (self.uplink_port, self.downlink_port))
+            logger.error("Error: unable to open socket on ports '%d' (up) and '%d' (down)" % (self.uplink_port, self.downlink_port))
             exit(0)
         self.trans = PprzTransport(msg_class)
 
     def stop(self):
-        print("End thread and close UDP link")
+        logger.info("End thread and close UDP link")
         self.running = False
         self.server.close()
 
@@ -74,7 +78,7 @@ class UdpMessagesInterface(threading.Thread):
                         if self.trans.parse_byte(c):
                             (sender_id, receiver_id, component_id, msg) = self.trans.unpack()
                             if self.verbose:
-                                print("New incoming message '%s' from %i (%i, %s) to %i" % (msg.name, sender_id, component_id, address, receiver_id))
+                                logger.info("New incoming message '%s' from %i (%i, %s) to %i" % (msg.name, sender_id, component_id, address, receiver_id))
                             # Callback function on new message
                             if self.id is None or self.id == receiver_id:
                                 self.callback(sender_id, address, msg, length, receiver_id, component_id)


### PR DESCRIPTION
I was going to implement the new request messages (as I asked on gitter) in this library and make a PR. While doing that I found some opportunities for refactoring the code and making the API more usable. 
In this PR I:
* Replaced all the print statements (outside the test code) with appropriate `logging` calls. It's more flexible on the library's user side. 
* Refactored a duplicate code in `messages_xml_map.py` into a method.

I have made more changes which I kept out of this PR becuase they might change the API slightly. I have to double check how they are used in the main paparazzi repo before merging so not to break any functionalities.

Thanks!