### PR TITLE
Refactored pprzlink python Ivy link interface to improve error reporting

### DIFF
--- a/lib/v1.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v1.0/python/pprzlink/messages_xml_map.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, print_function
 
 import os
-import logging
 
 # if PAPARAZZI_HOME is set use $PAPARAZZI_HOME/var/messages.xml
 # else assume this file is installed in var/lib/python/pprzlink
@@ -26,7 +25,6 @@ message_dictionary_id_name = {}
 message_dictionary_name_id = {}
 message_dictionary_broadcast = {}
 
-logger = logging.getLogger("PprzLink")
 
 
 class MessagesNotFound(Exception):

--- a/lib/v1.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v1.0/python/pprzlink/messages_xml_map.py
@@ -95,77 +95,76 @@ def _ensure_message_dictionary():
 
 def find_msg_by_name(name):
     _ensure_message_dictionary()
-    for msg_class in message_dictionary:
-        if name in message_dictionary[msg_class]:
+    for msg_class, msg_name in message_dictionary.items():
+        if name in msg_name:
             #print("found msg name %s in class %s" % (name, msg_class))
             return msg_class, name
-    logger.error("Error: msg_name %s not found." % name)
-    return None, None
+
+    raise ValueError("Error: msg_name %s not found." % name)
 
 
 def get_msgs(msg_class):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary:
-        return message_dictionary[msg_class]
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return []
+    if msg_class not in message_dictionary:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    return message_dictionary[msg_class]
 
 
 def get_msg_name(msg_class, msg_id):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary:
-        if msg_id in message_dictionary_id_name[msg_class]:
-            return message_dictionary_id_name[msg_class][msg_id]
-        else:
-            logger.error("Error: msg_id %d not found in msg_class %s." % (msg_id, msg_class))
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return ""
+    if msg_class not in message_dictionary:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_id not in message_dictionary_id_name[msg_class]:
+        raise ValueError("Error: msg_id %d not found in msg_class %s." % (msg_id, msg_class))
+
+    return message_dictionary_id_name[msg_class][msg_id]
 
 
 def get_msg_fields(msg_class, msg_name):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary:
-        if msg_name in message_dictionary[msg_class]:
-            return message_dictionary[msg_class][msg_name]
-        else:
-            logger.error("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return []
+    if msg_class not in message_dictionary:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_name not in message_dictionary[msg_class]:
+        raise ValueError("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
+
+    return message_dictionary[msg_class][msg_name]
 
 
 def get_msg_id(msg_class, msg_name):
     _ensure_message_dictionary()
-    try:
-        return message_dictionary_name_id[msg_class][msg_name]
-    except KeyError:
-        logger.error("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
-        return 0
+    if msg_class not in message_dictionary_name_id:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_name not in message_dictionary_name_id[msg_class]:
+        raise ValueError("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
+
+    return message_dictionary_name_id[msg_class][msg_name]
 
 
 def get_msg_fieldtypes(msg_class, msg_id):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary_types:
-        if msg_id in message_dictionary_types[msg_class]:
-            return message_dictionary_types[msg_class][msg_id]
-        else:
-            logger.error("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return []
+
+    if msg_class not in message_dictionary_types:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_id not in message_dictionary_types[msg_class]:
+        raise ValueError("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
+
+    return message_dictionary_types[msg_class][msg_id]
+
 
 def get_msg_fieldcoefs(msg_class, msg_id):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary_coefs:
-        if msg_id in message_dictionary_coefs[msg_class]:
-            return message_dictionary_coefs[msg_class][msg_id]
-        else:
-            logger.error("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return []
+    if msg_class not in message_dictionary_coefs:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_id not in message_dictionary_coefs[msg_class]:
+        raise ValueError("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
+
+    return message_dictionary_coefs[msg_class][msg_id]
 
 
 def test():

--- a/lib/v1.0/python/pprzlink/serial.py
+++ b/lib/v1.0/python/pprzlink/serial.py
@@ -54,11 +54,15 @@ class SerialMessagesInterface(threading.Thread):
                 c = self.ser.read(1)
                 if len(c) == 1:
                     if self.trans.parse_byte(c):
-                        (sender_id, msg) = self.trans.unpack()
-                        if self.verbose:  # Can be replaced with the log level
-                            logger.info("New incoming message '%s' from %i" % (msg.name, sender_id))
-                        # Callback function on new message 
-                        self.callback(sender_id, msg)
+                        try:
+                            (sender_id, msg) = self.trans.unpack()
+                        except ValueError as e:
+                            logger.warning("Ignoring unknown message, %s" % e)
+                        else:
+                            if self.verbose:  # Can be replaced with the log level
+                                logger.info("New incoming message '%s' from %i" % (msg.name, sender_id))
+                            # Callback function on new message
+                            self.callback(sender_id, msg)
 
         except StopIteration:
             pass

--- a/lib/v1.0/python/pprzlink/udp.py
+++ b/lib/v1.0/python/pprzlink/udp.py
@@ -74,11 +74,15 @@ class UdpMessagesInterface(threading.Thread):
                     length = len(msg)
                     for c in msg:
                         if self.trans.parse_byte(c):
-                            (sender_id, msg) = self.trans.unpack()
-                            if self.verbose:
-                                logger.info("New incoming message '%s' from %i (%s)" % (msg.name, sender_id, address))
-                            # Callback function on new message
-                            self.callback(sender_id, address, msg, length)
+                            try:
+                                (sender_id, msg) = self.trans.unpack()
+                            except ValueError as e:
+                                logger.warning("Ignoring unknown message, %s" % e)
+                            else:
+                                if self.verbose:
+                                    logger.info("New incoming message '%s' from %i (%s)" % (msg.name, sender_id, address))
+                                # Callback function on new message
+                                self.callback(sender_id, address, msg, length)
                 except socket.timeout:
                     pass
 

--- a/lib/v2.0/python/pprzlink/ivy.py
+++ b/lib/v2.0/python/pprzlink/ivy.py
@@ -18,7 +18,7 @@ elif platform.system() == 'Darwin':
 else:
     IVY_BUS = ""
 
-logger = logging.getLogger("PpzLink")
+logger = logging.getLogger("PprzLink")
 
 
 class IvyMessagesInterface(object):
@@ -138,10 +138,12 @@ class IvyMessagesInterface(object):
             msg_name = data.group(2)
             payload = data.group(3)
         # check which message class it is
-        msg_class, msg_name = messages_xml_map.find_msg_by_name(msg_name)
-        if msg_class is None:
+        try:
+            msg_class, msg_name = messages_xml_map.find_msg_by_name(msg_name)
+        except ValueError:
             logger.error("Ignoring unknown message " + ivy_msg)
             return
+
         msg = PprzMessage(msg_class, msg_name)
         msg.ivy_string_to_payload(payload)
         # pass non-telemetry messages with ac_id 0 or ac_id attrib value
@@ -167,14 +169,16 @@ class IvyMessagesInterface(object):
         Send a PprzMessage of datalink msg_class embedded in RAW_DATALINK message
 
         :param msg: PprzMessage
-        :returns: Number of clients the message sent to, None if msg was invalid
+        :returns: Number of clients the message was sent to
+        :raises: ValueError: if msg was invalid
+        :raises: RuntimeError: if the server is not running
         """
         if not isinstance(msg, PprzMessage):
-            logger.error("Can only send PprzMessage")
-            return None
+            raise ValueError("Expected msg to be PprzMessage, got " + type(msg) + " instead.")
+
         if "datalink" not in msg.msg_class:
-            logger.error("Message to embed in RAW_DATALINK needs to be of 'datalink' class")
-            return None
+            raise ValueError("Message to embed in RAW_DATALINK needs to be of 'datalink' class.")
+
         raw = PprzMessage("ground", "RAW_DATALINK")
         raw['ac_id'] = msg['ac_id']
         raw['message'] = msg.to_csv()
@@ -185,17 +189,19 @@ class IvyMessagesInterface(object):
         Send a message
 
         :param msg: PprzMessage or simple string
-        :param sender_id: Needed if sending a PprzMessage of telemetry msg_class, otherwise message class might be used instead
-        :returns: Number of clients the message sent to, None if msg was invalid
+        :param sender_id: Needed if sending a PprzMessage of telemetry msg_class, otherwise
+                          message class might be used instead
+        :returns: Number of clients the message was sent to
+        :raises: ValueError: if msg was invalid or `sender_id` not provided for telemetry messages
+        :raises: RuntimeError: if the server is not running
         """
         if not self._running:
-            logger.error("Ivy server not running!")
-            return
+            raise RuntimeError("Ivy server not running!")
+
         if isinstance(msg, PprzMessage):
             if "telemetry" in msg.msg_class:
                 if sender_id is None:
-                    logger.error("ac_id needed to send telemetry message.")
-                    return None
+                    raise ValueError("ac_id needed to send telemetry message.")
                 else:
                     return IvySendMsg("%d %s %s" % (sender_id, msg.name, msg.payload_to_ivy_string()))
             else:

--- a/lib/v2.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v2.0/python/pprzlink/messages_xml_map.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, print_function
 
 import os
-import logging
 
 # if PAPARAZZI_HOME is set use $PAPARAZZI_HOME/var/messages.xml
 # else assume this file is installed in var/lib/python/pprzlink
@@ -28,7 +27,6 @@ message_dictionary_class_id_name = {}
 message_dictionary_class_name_id = {}
 message_dictionary_broadcast = {}
 
-logger = logging.getLogger("PprzLink")
 
 
 class MessagesNotFound(Exception):

--- a/lib/v2.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v2.0/python/pprzlink/messages_xml_map.py
@@ -106,94 +106,93 @@ def _ensure_message_dictionary():
 
 def find_msg_by_name(name):
     _ensure_message_dictionary()
-    for msg_class in message_dictionary:
-        if name in message_dictionary[msg_class]:
+    for msg_class, msg_name in message_dictionary.items():
+        if name in msg_name:
             #print("found msg name %s in class %s" % (name, msg_class))
             return msg_class, name
-    logger.error("Error: msg_name %s not found." % name)
-    return None, None
+
+    raise ValueError("Error: msg_name %s not found." % name)
 
 
 def get_msgs(msg_class):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary:
-        return message_dictionary[msg_class]
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return []
+    if msg_class not in message_dictionary:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    return message_dictionary[msg_class]
 
 
 def get_class_name(class_id):
     _ensure_message_dictionary()
-    if class_id in message_dictionary_class_id_name:
-        return message_dictionary_class_id_name[class_id]
-    else:
-        logger.error("Error: class_id %d not found." % class_id)
-    return None
+    if class_id not in message_dictionary_class_id_name:
+        raise ValueError("Error: class_id %d not found." % class_id)
+
+    return message_dictionary_class_id_name[class_id]
+
 
 def get_class_id(class_name):
     _ensure_message_dictionary()
-    if class_name in message_dictionary_class_name_id:
-        return message_dictionary_class_name_id[class_name]
-    else:
-        logger.error("Error: class_name %s not found." % class_name)
-    return None
+    if class_name not in message_dictionary_class_name_id:
+        raise ValueError("Error: class_name %s not found." % class_name)
+
+    return message_dictionary_class_name_id[class_name]
 
 
 def get_msg_name(msg_class, msg_id):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary:
-        if msg_id in message_dictionary_id_name[msg_class]:
-            return message_dictionary_id_name[msg_class][msg_id]
-        else:
-            logger.error("Error: msg_id %d not found in msg_class %s." % (msg_id, msg_class))
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return ""
+    if msg_class not in message_dictionary:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_id not in message_dictionary_id_name[msg_class]:
+        raise ValueError("Error: msg_id %d not found in msg_class %s." % (msg_id, msg_class))
+
+    return message_dictionary_id_name[msg_class][msg_id]
 
 
 def get_msg_fields(msg_class, msg_name):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary:
-        if msg_name in message_dictionary[msg_class]:
-            return message_dictionary[msg_class][msg_name]
-        else:
-            logger.error("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return []
+    if msg_class not in message_dictionary:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_name not in message_dictionary[msg_class]:
+        raise ValueError("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
+
+    return message_dictionary[msg_class][msg_name]
 
 
 def get_msg_id(msg_class, msg_name):
     _ensure_message_dictionary()
-    try:
-        return message_dictionary_name_id[msg_class][msg_name]
-    except KeyError:
-        logger.error("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
-        return 0
+    if msg_class not in message_dictionary_name_id:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_name not in message_dictionary_name_id[msg_class]:
+        raise ValueError("Error: msg_name %s not found in msg_class %s." % (msg_name, msg_class))
+
+    return message_dictionary_name_id[msg_class][msg_name]
 
 
 def get_msg_fieldtypes(msg_class, msg_id):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary_types:
-        if msg_id in message_dictionary_types[msg_class]:
-            return message_dictionary_types[msg_class][msg_id]
-        else:
-            logger.error("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return []
+
+    if msg_class not in message_dictionary_types:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_id not in message_dictionary_types[msg_class]:
+        raise ValueError("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
+
+    return message_dictionary_types[msg_class][msg_id]
+
 
 def get_msg_fieldcoefs(msg_class, msg_id):
     _ensure_message_dictionary()
-    if msg_class in message_dictionary_coefs:
-        if msg_id in message_dictionary_coefs[msg_class]:
-            return message_dictionary_coefs[msg_class][msg_id]
-        else:
-            logger.error("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
-    else:
-        logger.error("Error: msg_class %s not found." % msg_class)
-    return []
+
+    if msg_class not in message_dictionary_coefs:
+        raise ValueError("Error: msg_class %s not found." % msg_class)
+
+    if msg_id not in message_dictionary_coefs[msg_class]:
+        raise ValueError("Error: message with ID %d not found in msg_class %s." % (msg_id, msg_class))
+
+    return message_dictionary_coefs[msg_class][msg_id]
 
 
 def test():

--- a/lib/v2.0/python/pprzlink/serial.py
+++ b/lib/v2.0/python/pprzlink/serial.py
@@ -57,12 +57,16 @@ class SerialMessagesInterface(threading.Thread):
                 c = self.ser.read(1)
                 if len(c) == 1:
                     if self.trans.parse_byte(c):
-                        (sender_id, receiver_id, component_id, msg) = self.trans.unpack()
-                        if self.verbose:  # See the note on the same line in v1.0
-                            logger.info("New incoming message '%s' from %i (%i) to %i" % (msg.name, sender_id, component_id, receiver_id))
-                        # Callback function on new message
-                        if self.id == receiver_id:
-                            self.callback(sender_id, msg)
+                        try:
+                            (sender_id, receiver_id, component_id, msg) = self.trans.unpack()
+                        except ValueError as e:
+                            logger.warning("Ignoring unknown message, %s" % e)
+                        else:
+                            if self.verbose:  # See the note on the same line in v1.0
+                                logger.info("New incoming message '%s' from %i (%i) to %i" % (msg.name, sender_id, component_id, receiver_id))
+                            # Callback function on new message
+                            if self.id == receiver_id:
+                                self.callback(sender_id, msg)
 
         except StopIteration:
             pass

--- a/lib/v2.0/python/pprzlink/udp.py
+++ b/lib/v2.0/python/pprzlink/udp.py
@@ -76,12 +76,16 @@ class UdpMessagesInterface(threading.Thread):
                     length = len(msg)
                     for c in msg:
                         if self.trans.parse_byte(c):
-                            (sender_id, receiver_id, component_id, msg) = self.trans.unpack()
-                            if self.verbose:
-                                logger.info("New incoming message '%s' from %i (%i, %s) to %i" % (msg.name, sender_id, component_id, address, receiver_id))
-                            # Callback function on new message
-                            if self.id is None or self.id == receiver_id:
-                                self.callback(sender_id, address, msg, length, receiver_id, component_id)
+                            try:
+                                (sender_id, receiver_id, component_id, msg) = self.trans.unpack()
+                            except ValueError as e:
+                                logger.warning("Ignoring unknown message, %s" % e)
+                            else:
+                                if self.verbose:
+                                    logger.info("New incoming message '%s' from %i (%i, %s) to %i" % (msg.name, sender_id, component_id, address, receiver_id))
+                                # Callback function on new message
+                                if self.id is None or self.id == receiver_id:
+                                    self.callback(sender_id, address, msg, length, receiver_id, component_id)
                 except socket.timeout:
                     pass
 


### PR DESCRIPTION
xref #116 

Changes:
* restructured some if statements to reduce nesting and imrprove readability
* Errors regarding the program being in the wrong state (e.g. trying to send message before starting the Ivy link) or invalid inputs to functions now raise exceptions instead of returning `None`. It's just a best-practices in Python that gives the library user more options for handling errors.
* improved/updated doc strings

---

This changes the class's interface (`send` and `send_raw_datalink` methods' to be more specific) and could become backwards-incompatible. I cross-checked usages of `IvyMessagesInterface` with the [main repository](https://github.com/paparazzi/paparazzi), including the submoduled projects. Most of them were only subscribing to certain messages and weren't using these methods. The ones which sent messages were not sending `telemetry` messages that can in an special case raise `ValueError`. To best of my knowledge, this is safe to merge, but it never hurts to have a second pair of more experienced eyes review it.