### PR TITLE
Add request messages

### DIFF
--- a/lib/v1.0/python/pprzlink/ivy.py
+++ b/lib/v1.0/python/pprzlink/ivy.py
@@ -110,6 +110,7 @@ class IvyMessagesInterface(object):
     def parse_pprz_msg(callback, ivy_msg):
         """
         Parse an Ivy message into a PprzMessage.
+
         :param callback: function to call with ac_id and parsed PprzMessage as params
         :param ivy_msg: Ivy message string to parse into PprzMessage
         """
@@ -192,7 +193,6 @@ class IvyMessagesInterface(object):
         :returns: Number of clients the message was sent to
         :raises: ValueError: if msg was invalid or `ac_id` not provided for telemetry messages
         :raises: RuntimeError: if the server is not running
-
         """
         if not self._running:
             raise RuntimeError("Ivy server not running!")
@@ -222,6 +222,8 @@ class IvyMessagesInterface(object):
         :type request_name: str
         :type callback: Callable[[str, PprzMessage], Any]
         :type request_extra_data: Dict[str, Any]
+        :raises: ValueError: if msg was invalid or `ac_id` not provided for telemetry messages
+        :raises: RuntimeError: if the server is not running
         """
         new_id = RequestUIDFactory.generate_uid()
         regex = r"^((\S*\s*)?%s %s %s( .*|$))" % (new_id, class_name, request_name)

--- a/lib/v1.0/python/pprzlink/ivy.py
+++ b/lib/v1.0/python/pprzlink/ivy.py
@@ -97,22 +97,59 @@ class IvyMessagesInterface(object):
         if not isinstance(regex_or_msg,PprzMessage):
             regex = regex_or_msg
         else:
-            regex = '^([^ ]* +%s( .*|$))'%(regex_or_msg.name)
+            regex = '^([^ ]* +%s( .*|$))' % (regex_or_msg.name)
 
-        bind_id = IvyBindMsg(lambda agent, *larg: self.parse_pprz_msg(callback, larg[0]), regex)
-        self.bindings[bind_id] = (callback, regex)
-        return bind_id
+        def _parse_and_call_callback(agent, *larg):
+            params = self.parse_pprz_msg(larg[0])
+            if params:
+                callback(*params)
+
+        return self.bind_raw(
+            callback=_parse_and_call_callback,
+            regex=regex
+        )
+
+    def subscribe_request_answerer(self, callback, request_name):
+        """
+        Subscribe to advanced request messages.
+
+        :param callback: Should return the answer as a PprzMessage
+        :param request_name: Request message name to listen to (without `_REQ` suffix)
+        :type callback: Callable[[int, PprzMessage], PprzMessage]
+        :type request_name: str
+        :return: binding id
+        """
+        regex = r'^(\S*\s+\S*\s+%s_REQ.*)' % request_name
+        def _callback_wrapper(_, *larg):
+            params = self.parse_pprz_msg(larg[0])
+            if not params:
+                return
+            ac_id, request_id, msg = params
+            try:
+                msg = callback(ac_id, msg)
+            except Exception:
+                logger.error('Error while answering a request message.')
+                import traceback
+                traceback.print_exc()
+            else:
+                self.send(" ".join((
+                    request_id, msg.msg_class, request_name, msg.payload_to_ivy_string()
+                )))
+        return self.bind_raw(
+            callback=_callback_wrapper,
+            regex=regex
+        )
 
     def unsubscribe(self, bind_id):
         self.unbind(bind_id)
 
     @staticmethod
-    def parse_pprz_msg(callback, ivy_msg):
+    def parse_pprz_msg(ivy_msg):
         """
         Parse an Ivy message into a PprzMessage.
 
-        :param callback: function to call with ac_id and parsed PprzMessage as params
         :param ivy_msg: Ivy message string to parse into PprzMessage
+        :return ac_id, request_id, msg: The parameters to be passed to callback
         """
         # normal format is "sender_name msg_name msg_payload..."
         # advanced format has requests and answers (with request_id as 'pid_index')
@@ -126,8 +163,10 @@ class IvyMessagesInterface(object):
         if re.search("[0-9]+_[0-9]+", data.group(1)) or re.search("[0-9]+_[0-9]+", data.group(2)):
             if re.search("[0-9]+_[0-9]+", data.group(1)):
                 sender_name = data.group(2)
+                request_id = data.group(1)
             else:
                 sender_name = data.group(1)
+                request_id = data.group(2)
             # this is an advanced type, split again
             data = re.search("(\S+) +(.*)", data.group(3))
             msg_name = data.group(1)
@@ -137,6 +176,7 @@ class IvyMessagesInterface(object):
             sender_name = data.group(1)
             msg_name = data.group(2)
             payload = data.group(3)
+            request_id = None
         # check which message class it is
         try:
             msg_class, msg_name = messages_xml_map.find_msg_by_name(msg_name)
@@ -155,6 +195,7 @@ class IvyMessagesInterface(object):
                     ac_id = int(sender_name)
             except ValueError:
                 logger.warning("ignoring message " + ivy_msg)
+                return None
         else:
             if 'ac_id' in msg.fieldnames:
                 ac_id_idx = msg.fieldnames.index('ac_id')
@@ -162,7 +203,10 @@ class IvyMessagesInterface(object):
             else:
                 ac_id = 0
         # finally call the callback, passing the aircraft id and parsed message
-        callback(ac_id, msg)
+        if request_id:
+            return ac_id, request_id, msg
+        else:
+            return ac_id, msg
 
     def send_raw_datalink(self, msg):
         """

--- a/lib/v1.0/python/pprzlink/ivy.py
+++ b/lib/v1.0/python/pprzlink/ivy.py
@@ -9,7 +9,7 @@ import platform
 
 from .message import PprzMessage
 from . import messages_xml_map
-
+from .request_uid import RequestUIDFactory
 
 if os.getenv('IVY_BUS') is not None:
     IVY_BUS = os.getenv('IVY_BUS')
@@ -25,6 +25,7 @@ class IvyMessagesInterface(object):
     def __init__(self, agent_name=None, start_ivy=True, verbose=False, ivy_bus=IVY_BUS):
         if agent_name is None:
             agent_name = "IvyMessagesInterface %i" % os.getpid()
+        self.agent_name = agent_name
         self.verbose = verbose
         self._ivy_bus = ivy_bus
         self._running = False
@@ -91,7 +92,7 @@ class IvyMessagesInterface(object):
         TODO: possibility to directly specify PprzMessage instead of regex
 
         :param callback: function called on new message with ac_id and PprzMessage as params
-        :param regex: regular expression for matching message
+        :param regex_or_msg: regular expression for matching message or a PprzMessage object to subscribe to
         """
         if not isinstance(regex_or_msg,PprzMessage):
             regex = regex_or_msg
@@ -206,3 +207,39 @@ class IvyMessagesInterface(object):
                 return IvySendMsg("%s %s %s" % (msg.msg_class, msg.name, msg.payload_to_ivy_string()))
         else:
             return IvySendMsg(msg)
+
+    def send_request(self, class_name, request_name, callback, **request_extra_data):
+        """
+        Send a data request message and passes the result directly to the callback method.
+
+        :return: Number of clients this message was sent to.
+        :rtype: int
+        :param class_name: Message class, the same as :ref:`PprzMessage.__init__`
+        :param request_name: Request name (without the _REQ suffix)
+        :param callback: Callback function that accepts two parameters: 1. aircraft id as int 2. The response message
+        :param request_extra_data: Payload that will be sent with the request if any
+        :type class_name: str
+        :type request_name: str
+        :type callback: Callable[[str, PprzMessage], Any]
+        :type request_extra_data: Dict[str, Any]
+        """
+        new_id = RequestUIDFactory.generate_uid()
+        regex = r"^((\S*\s*)?%s %s %s( .*|$))" % (new_id, class_name, request_name)
+
+        def data_request_callback(ac_id, msg):
+            try:
+                callback(int(ac_id), msg)
+            except Exception as e:
+                raise e
+            finally:
+                self.unsubscribe(binding_id)
+
+        binding_id = self.subscribe(data_request_callback, regex)
+        request_message = PprzMessage(class_name, "%s_REQ" % request_name)
+        for k, v in request_extra_data.items():
+            request_message.set_value_by_name(k, v)
+
+        data_request_message = ' '.join((
+            self.agent_name, new_id, request_message.name, request_message.payload_to_ivy_string()
+        ))
+        return self.send(data_request_message)

--- a/lib/v1.0/python/pprzlink/request_uid.py
+++ b/lib/v1.0/python/pprzlink/request_uid.py
@@ -1,0 +1,18 @@
+class RequestUIDFactory:
+    _generator = None
+
+    @classmethod
+    def _unique_id_generator(cls):
+        import os
+        pid = os.getpid()
+
+        sequence_number = 0
+        while True:
+            sequence_number = sequence_number + 1
+            yield f'{pid}_{sequence_number}'
+
+    @classmethod
+    def generate_uid(cls):
+        if cls._generator is None:
+            cls._generator = cls._unique_id_generator()
+        return next(cls._generator)

--- a/lib/v2.0/python/pprzlink/ivy.py
+++ b/lib/v2.0/python/pprzlink/ivy.py
@@ -113,6 +113,7 @@ class IvyMessagesInterface(object):
     def parse_pprz_msg(callback, ivy_msg):
         """
         Parse an Ivy message into a PprzMessage.
+
         :param callback: function to call with ac_id and parsed PprzMessage as params
         :param ivy_msg: Ivy message string to parse into PprzMessage
         """
@@ -228,6 +229,8 @@ class IvyMessagesInterface(object):
         :type request_name: str
         :type callback: Callable[[str, PprzMessage], Any]
         :type request_extra_data: Dict[str, Any]
+        :raises: ValueError: if msg was invalid or `sender_id` not provided for telemetry messages
+        :raises: RuntimeError: if the server is not running
         """
         new_id = RequestUIDFactory.generate_uid()
         regex = r"^((\S*\s*)?%s %s %s( .*|$))" % (new_id, class_name, request_name)

--- a/lib/v2.0/python/pprzlink/request_uid.py
+++ b/lib/v2.0/python/pprzlink/request_uid.py
@@ -1,0 +1,18 @@
+class RequestUIDFactory:
+    _generator = None
+
+    @classmethod
+    def _unique_id_generator(cls):
+        import os
+        pid = os.getpid()
+
+        sequence_number = 0
+        while True:
+            sequence_number = sequence_number + 1
+            yield f'{pid}_{sequence_number}'
+
+    @classmethod
+    def generate_uid(cls):
+        if cls._generator is None:
+            cls._generator = cls._unique_id_generator()
+        return next(cls._generator)


### PR DESCRIPTION
`IvyMessagesInterface` now has a `send_request` method that implements [advanced request mechanism](https://wiki.paparazziuav.org/wiki/DevGuide/Server_GCS_com#Advanced_request_mechanism).

Example:

```
>>> from pprzlink import ivy
... _ivy = ivy.IvyMessagesInterface(agent_name='MyTestAgent', start_ivy=True)

>>> _ivy.send_request('ground', 'AIRCRAFTS', callback=lambda *args: print(*args))
2  # return from send_request
0 ground.AIRCRAFTS {ac_list: ['14']}  # Callback being executed


>>> _ivy.send_request('ground', 'CONFIG', callback=lambda *args: print(*args), ac_id=14)
2
14 ground.CONFIG {ac_id : 14, flight_plan : file:///home/mjafar/Documents/paparazzi/var/aircrafts/Microjet/flight_plan.xml, airframe : file:///home/mjafar/Documents/paparazzi/conf/airframes/examples/microjet_lisa_m.xml, radio : file:///home/mjafar/Documents/paparazzi/conf/radios/cockpitMM.xml, settings : file:///home/mjafar/Documents/paparazzi/var/aircrafts/Microjet/settings.xml, default_gui_color : #6293ba, ac_name : Microjet}
```