### PR TITLE
Fixed python string formating to avoid error

### DIFF
--- a/lib/v1.0/python/pprzlink/request_uid.py
+++ b/lib/v1.0/python/pprzlink/request_uid.py
@@ -26,7 +26,7 @@ class RequestUIDFactory:
         sequence_number = 0
         while True:
             sequence_number = sequence_number + 1
-            yield f'{pid}_{sequence_number}'
+            yield '%d_%d'.format(pid, sequence_number)
 
     @classmethod
     def generate_uid(cls):

--- a/lib/v1.0/python/pprzlink/request_uid.py
+++ b/lib/v1.0/python/pprzlink/request_uid.py
@@ -26,7 +26,7 @@ class RequestUIDFactory:
         sequence_number = 0
         while True:
             sequence_number = sequence_number + 1
-            yield '%d_%d'.format(pid, sequence_number)
+            yield '{}_{}'.format(pid, sequence_number)
 
     @classmethod
     def generate_uid(cls):

--- a/lib/v2.0/python/pprzlink/request_uid.py
+++ b/lib/v2.0/python/pprzlink/request_uid.py
@@ -26,7 +26,7 @@ class RequestUIDFactory:
         sequence_number = 0
         while True:
             sequence_number = sequence_number + 1
-            yield f'{pid}_{sequence_number}'
+            yield '%d_%d'.format(pid, sequence_number)
 
     @classmethod
     def generate_uid(cls):

--- a/lib/v2.0/python/pprzlink/request_uid.py
+++ b/lib/v2.0/python/pprzlink/request_uid.py
@@ -26,7 +26,7 @@ class RequestUIDFactory:
         sequence_number = 0
         while True:
             sequence_number = sequence_number + 1
-            yield '%d_%d'.format(pid, sequence_number)
+            yield '{}_{}'.format(pid, sequence_number)
 
     @classmethod
     def generate_uid(cls):


### PR DESCRIPTION
Hello All,

I was working on a python program to automate testing, and I was attempting to use pprzlink to connect to the vehicle during this process. When I included the required files (i.e., from pprzlink.ivy import IvyMessagesInterface) i got an syntax error on line that I replaced. I simply changed the statement ...
f'{pid}_{sequence_number}' 
... to the line ...
'%_%'.format(pid, sequence_number)

I replaced this line in V1.0 and V2.0


Here is the error message....

Traceback (most recent call last):
  File "automate.py", line 14, in <module>
    from pprzlink.ivy import IvyMessagesInterface
  File "/home/jb/paparazzi/var/lib/python/pprzlink/ivy.py", line 12, in <module>
    from pprzlink.request_uid import RequestUIDFactory
  File "/home/jb/paparazzi/var/lib/python/pprzlink/request_uid.py", line 12
    yield f'{pid}_{sequence_number}'
                                   ^
SyntaxError: invalid syntax