### PR TITLE
minor static-cast to allow compiling on MacOSX clang

### DIFF
--- a/lib/v2.0/C++/pprzlink/Message.cpp
+++ b/lib/v2.0/C++/pprzlink/Message.cpp
@@ -3,16 +3,16 @@
  * This file is part of PprzLinkCPP
  *
  * PprzLinkCPP is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
+ * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
  * PprzLinkCPP is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License
+ * You should have received a copy of the GNU General Public License
  * along with ModemTester.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
@@ -27,11 +27,11 @@
 
 namespace pprzlink {
 
-  Message::Message() : sender_id(0),receiver_id(0),component_id(0)
+  Message::Message() : sender_id(static_cast<uint8_t>(0)),receiver_id(static_cast<uint8_t>(0)),component_id(static_cast<uint8_t>(0))
   {
   }
 
-  Message::Message(const MessageDefinition &def) : def(def),sender_id(0),receiver_id(0),component_id(0)
+  Message::Message(const MessageDefinition &def) : def(def),sender_id(static_cast<uint8_t>(0)),receiver_id(static_cast<uint8_t>(0)),component_id(static_cast<uint8_t>(0))
   {
   }
 


### PR DESCRIPTION
Update the variant for macosx, thanx to AlexB and FabienB: force the cast of 0 to uint_8