### PR TITLE
[C++] Do not build C++ library by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,6 @@ endif
 
 all: libpprzlink
 
-# Build and install C++ if lib versoin is 2.0 (Should test if version is more than 2.0...)
-ifeq ($(PPRZLINK_LIB_VERSION), 2.0)
-libpprzlink: libpprzlink++
-libpprzlink-install: libpprzlink++-install
-endif
-
 # This compiles the sources then copy the library
 libpprzlink++:
 	$(Q)Q=$(Q) DESTDIR=$(DESTDIR)/C++ $(MAKE) -C lib/v$(PPRZLINK_LIB_VERSION)/C++ libpprzlink++


### PR DESCRIPTION
The C++ lib depends on third party libraries that must be installed by the user.
Since the C++ lib is not used in core paparazzi, it should not make the paparazzi build fail.
This prevent building C++ lib by default.
Set `BUILD_PPRZLINK++=ON` to build it.
