### PR TITLE
Make all ground class coordinates double, 7 digit precision.

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -2754,8 +2754,8 @@
       <field name="roll"   type="float" unit="deg"/>
       <field name="pitch"  type="float" unit="deg"/>
       <field name="heading" type="float" unit="deg"/>
-      <field name="lat"    type="float" unit="deg"/>
-      <field name="long"   type="float" unit="deg"/>
+      <field name="lat"    type="double" unit="deg" format="%.7f"/>
+      <field name="long"   type="double" unit="deg" format="%.7f"/>
       <field name="speed"  type="float" unit="m/s"/>
       <field name="course" type="float" unit="deg" format="%.1f"/>
       <field name="alt"    type="float" unit="m"/>
@@ -2784,8 +2784,8 @@
       <field name="cur_stage"   type="uint8"/>
       <field name="block_time"  type="uint32"/>
       <field name="stage_time"  type="uint32"/>
-      <field name="target_lat" type="float" unit="deg"/>
-      <field name="target_long" type="float" unit="deg"/>
+      <field name="target_lat" type="double" unit="deg" format="%.7f"/>
+      <field name="target_long" type="double" unit="deg" format="%.7f"/>
       <field name="target_climb"   type="float" unit="m/s"/>
       <field name="target_alt"     type="float" unit="m"/>
       <field name="target_course" type="float" unit="deg"/>
@@ -2796,8 +2796,8 @@
       <field name="ac_id" type="string"/>
       <field name="lats" type="string" format="csv"/>
       <field name="longs" type="string" format="csv"/>
-      <field name="cam_target_lat" type="float" unit="deg"/>
-      <field name="cam_target_long" type="float" unit="deg"/>
+      <field name="cam_target_lat" type="double" unit="deg" format="%.7f"/>
+      <field name="cam_target_long" type="double" unit="deg" format="%.7f"/>
     </message>
 
     <message name="ENGINE_STATUS" id="15">
@@ -2851,8 +2851,8 @@
     </message>
 
     <message name="WORLD_ENV_REQ" id="21">
-      <field name="lat"  type="float" unit="deg"></field>
-      <field name="long" type="float" unit="deg"></field>
+      <field name="lat"  type="double" unit="deg" format="%.7f"></field>
+      <field name="long" type="double" unit="deg" format="%.7f"></field>
       <field name="alt"  type="float" unit="m"></field>
       <field name="east" type="float" unit="m"></field> <!-- local ref. -->
       <field name="north" type="float" unit="m"></field> <!-- local ref. -->
@@ -2861,24 +2861,24 @@
 
     <message name="CIRCLE_STATUS" id="22">
       <field name="ac_id" type="string"/>
-      <field name="circle_lat" type="float" unit="deg"/>
-      <field name="circle_long" type="float" unit="deg"/>
+      <field name="circle_lat" type="double" unit="deg" format="%.7f"/>
+      <field name="circle_long" type="double" unit="deg" format="%.7f"/>
       <field name="radius" type="int16" unit="m"/>
      </message>
 
     <message name="SEGMENT_STATUS" id="23">
       <field name="ac_id" type="string"/>
-      <field name="segment1_lat" type="float" unit="deg"/>
-      <field name="segment1_long" type="float" unit="deg"/>
-      <field name="segment2_lat" type="float" unit="deg"/>
-      <field name="segment2_long" type="float" unit="deg"/>
+      <field name="segment1_lat" type="double" unit="deg" format="%.7f"/>
+      <field name="segment1_long" type="double" unit="deg" format="%.7f"/>
+      <field name="segment2_lat" type="double" unit="deg" format="%.7f"/>
+      <field name="segment2_long" type="double" unit="deg" format="%.7f"/>
     </message>
 
     <message name="MOVE_WAYPOINT" id="24">
       <field name="ac_id" type="string"/>
       <field name="wp_id" type="uint8"/>
-      <field name="lat"  type="float" unit="deg" format="%.7f"/>
-      <field name="long"  type="float" unit="deg" format="%.7f"/>
+      <field name="lat"  type="double" unit="deg" format="%.7f"/>
+      <field name="long"  type="double" unit="deg" format="%.7f"/>
       <field name="alt"    type="float" unit="m"/>
     </message>
 
@@ -2911,18 +2911,18 @@
     <message name="WAYPOINT_MOVED" id="30">
       <field name="ac_id" type="string"/>
       <field name="wp_id" type="uint8"/>
-      <field name="lat"  type="float" unit="deg" format="%.7f"/>
-      <field name="long"  type="float" unit="deg" format="%.7f"/>
+      <field name="lat"  type="double" unit="deg" format="%.7f"/>
+      <field name="long"  type="double" unit="deg" format="%.7f"/>
       <field name="alt" type="float" unit="m"/>
       <field name="ground_alt" type="float" unit="m"/>
     </message>
 
     <message name="SURVEY_STATUS" id="31">
       <field name="ac_id" type="string"/>
-      <field name="east_long" type="float" unit="deg"/>
-      <field name="north_lat" type="float" unit="deg"/>
-      <field name="west_long" type="float" unit="deg"/>
-      <field name="south_lat" type="float" unit="deg"/>
+      <field name="east_long" type="double" unit="deg" format="%.7f"/>
+      <field name="north_lat" type="double" unit="deg" format="%.7f"/>
+      <field name="west_long" type="double" unit="deg" format="%.7f"/>
+      <field name="south_lat" type="double" unit="deg" format="%.7f"/>
     </message>
 
     <message name="TELEMETRY_STATUS" id="32">


### PR DESCRIPTION
Float precision around 43° translate to approx 42cm, which is significant at the scale of a flight arena.
This PR makes all ground coordinates double, with 7 digit precision, which should translate to approx 1cm precision.