### PR TITLE
[Ivy, Python] Fix trailing space.

### DIFF
--- a/lib/v1.0/python/pprzlink/message.py
+++ b/lib/v1.0/python/pprzlink/message.py
@@ -181,18 +181,18 @@ class PprzMessage(object):
         return str(self.name) + ';' + self.payload_to_ivy_string(sep=';')
 
     def payload_to_ivy_string(self, sep=' '):
-        ivy_str = ''
+        fields = []
         for idx, t in enumerate(self.fieldtypes):
             if "char[" in t:
                 str_value =''
                 for c in self.fieldvalues[idx]:
                     str_value += c
-                ivy_str += '"' + str_value + '"'
+                fields.append('"' + str_value + '"')
             elif '[' in t:
-                ivy_str += ','.join([str(x) for x in self.fieldvalues[idx]])
+                fields.append(','.join([str(x) for x in self.fieldvalues[idx]]))
             else:
-                ivy_str += str(self.fieldvalues[idx])
-            ivy_str += sep
+                fields.append(str(self.fieldvalues[idx]))
+            ivy_str = sep.join(fields)
         return ivy_str
 
     def ivy_string_to_payload(self, data):

--- a/lib/v2.0/python/pprzlink/message.py
+++ b/lib/v2.0/python/pprzlink/message.py
@@ -193,7 +193,7 @@ class PprzMessage(object):
         return str(self.name) + ';' + self.payload_to_ivy_string(sep=';')
 
     def payload_to_ivy_string(self, sep=' '):
-        ivy_str = ''
+        fields = []
         for idx, t in enumerate(self.fieldtypes):
             if "char[" in t:
                 str_value =''
@@ -202,12 +202,12 @@ class PprzMessage(object):
                         str_value += c.decode()
                     else:
                         str_value += c
-                ivy_str += '"' + str_value + '"'
+                fields.append('"' + str_value + '"')
             elif '[' in t:
-                ivy_str += ','.join([str(x) for x in self.fieldvalues[idx]])
+                fields.append(','.join([str(x) for x in self.fieldvalues[idx]]))
             else:
-                ivy_str += str(self.fieldvalues[idx])
-            ivy_str += sep
+                fields.append(str(self.fieldvalues[idx]))
+        ivy_str = sep.join(fields)
         return ivy_str
 
     def ivy_string_to_payload(self, data):


### PR DESCRIPTION
Python pprzlink for Ivy leave a trailing space character. This PR fix it.