### PR TITLE
Stream external pose message from vision system so that it can be logged

### DIFF
--- a/message_definitions/v1.0/messages.xml
+++ b/message_definitions/v1.0/messages.xml
@@ -377,7 +377,22 @@
       <field name="exponential"         type="uint8" unit="bool">Exponential chirp active</field>
     </message>
 
-    <!-- 46 is free-->
+    <message name="EXTERNAL_POSE_2" id="46">
+      <description>
+        Position, speed and orientation in local frame from a remote vision system
+      </description>
+      <field name="timestamp" type="float" unit="mus">Timestamp from the measurement</field>
+      <field name="ned_x"     type="float" unit="m">NED x position in vision frame</field>
+      <field name="ned_y"     type="float" unit="m">NED y position in vision frame</field>
+      <field name="ned_z"     type="float" unit="m">NED z position in vision frame</field>
+      <field name="ned_xd"    type="float" unit="m/s">NED x speed in vision frame</field>
+      <field name="ned_yd"    type="float" unit="m/s">NED y speed in vision frame</field>
+      <field name="ned_zd"    type="float" unit="m/s">NED z speed in vision frame</field>
+      <field name="body_qi"   type="float">Body quaternion i in NED to body</field>
+      <field name="body_qx"   type="float">Body quaternion x in NED to body</field>
+      <field name="body_qy"   type="float">Body quaternion y in NED to body</field>
+      <field name="body_qz"   type="float">Body quaternion z in NED to body</field>
+    </message>
 
     <message name="WP_MOVED_LLA" id="47">
       <field name="wp_id" type="uint8"/>


### PR DESCRIPTION
Added a new message similar to the original EXT_POSE but that can be added to the telemtry files and logged. Useful for who wants to compare the vision system data with outputs of new (or old) INS filters. Pull request with modified INS modules which stream this message is on the way!