### PR TITLE
Fix List[str] in python <= 3.8 with future annotations

### DIFF
--- a/lib/v1.0/python/pprzlink/message.py
+++ b/lib/v1.0/python/pprzlink/message.py
@@ -20,7 +20,7 @@ Paparazzi message representation
 
 """
 
-from __future__ import division, print_function
+from __future__ import division, print_function, annotations
 import sys
 import json
 import struct

--- a/lib/v1.0/python/pprzlink/messages_xml_map.py
+++ b/lib/v1.0/python/pprzlink/messages_xml_map.py
@@ -17,7 +17,7 @@
 #
 
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, annotations
 
 import os
 

--- a/lib/v2.0/python/src/pprzlink/message.py
+++ b/lib/v2.0/python/src/pprzlink/message.py
@@ -20,7 +20,7 @@ Paparazzi message representation
 
 """
 
-from __future__ import division, print_function,annotations
+from __future__ import division, print_function, annotations
 import sys
 import json,csv
 import struct

--- a/lib/v2.0/python/src/pprzlink/messages_xml_map.py
+++ b/lib/v2.0/python/src/pprzlink/messages_xml_map.py
@@ -17,7 +17,7 @@
 #
 
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, annotations
 
 import os
 


### PR DESCRIPTION
Is python 3.8 officially not supported anymore or can we still add the following PR to fix the errors below in all python tools since #188

```
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/home/mavlab/paparazzi/sw/ground_segment/python/wind/wind.py", line 23, in 
import wind_frame
File "/home/mavlab/paparazzi/sw/ground_segment/python/wind/wind_frame.py", line 33, in 
from pprzlink.ivy import IvyMessagesInterface
File "/home/mavlab/paparazzi/var/lib/python/pprzlink/ivy.py", line 27, in 
from pprzlink.message import PprzMessage
File "/home/mavlab/paparazzi/var/lib/python/pprzlink/message.py", line 34, in 
from pprzlink import messages_xml_map
File "/home/mavlab/paparazzi/var/lib/python/pprzlink/messages_xml_map.py", line 190, in 
def get_msg_fields(msg_class:str, msg_name:str) -> list[str]:
TypeError: 'type' object is not subscriptable
```